### PR TITLE
Move post share button into the jumbo hero

### DIFF
--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -38,6 +38,7 @@
               <li>{{ date | dateFormat }}</li>
             {% endif %}
           </ul>
+          {% include "actions.html" %}
         </div>
       </div>
     </div>

--- a/_includes/layouts/post.html
+++ b/_includes/layouts/post.html
@@ -18,7 +18,6 @@
         <div class="post-content">
           {{ content | safe }}
         </div>
-        {% include "actions.html" %}
         {% include "connect.html" %}
       </div>
       <div class="col-12 col-sm-12 col-md-2 col-lg-2 col-xl-2"></div>


### PR DESCRIPTION
## Move post share button into the jumbo (2026-07-08)

- Share button now appears right under the title/byline on news posts, instead of below the article body
- Matches the placement pattern already used on scangov.org
- No change to any other page type (homepage, people pages, etc.) — they never had the share button and still don't
