### PR TITLE
Consolidate post topics/keywords into one field

### DIFF
--- a/_config/filters.js
+++ b/_config/filters.js
@@ -49,19 +49,16 @@ export default function(eleventyConfig) {
 		return (posts || []).filter(post => post.data && post.data.author === slug);
 	});
 
-	eleventyConfig.addFilter("relatedPosts", (allPosts, currentUrl, keywords, topics) => {
-		const currentTerms = new Set([
-			...(Array.isArray(keywords) ? keywords : []),
-			...(Array.isArray(topics) ? topics : []),
-		].map(t => String(t).toLowerCase()));
+	eleventyConfig.addFilter("relatedPosts", (allPosts, currentUrl, topics) => {
+		const currentTerms = new Set(
+			(Array.isArray(topics) ? topics : []).map(t => String(t).toLowerCase())
+		);
 
 		return (allPosts || [])
 			.filter(post => post.url !== currentUrl)
 			.map(post => {
-				const postTerms = [
-					...(Array.isArray(post.data.keywords) ? post.data.keywords : []),
-					...(Array.isArray(post.data.topics) ? post.data.topics : []),
-				].map(t => String(t).toLowerCase());
+				const postTerms = (Array.isArray(post.data.topics) ? post.data.topics : [])
+					.map(t => String(t).toLowerCase());
 				const score = postTerms.filter(t => currentTerms.has(t)).length;
 				return { post, score };
 			})

--- a/_includes/layouts/post.html
+++ b/_includes/layouts/post.html
@@ -23,7 +23,7 @@
       <div class="col-12 col-sm-12 col-md-2 col-lg-2 col-xl-2"></div>
     </div>
   </div>
-  {% set morePosts = collections.postsByDate | relatedPosts(page.url, keywords, topics) %}
+  {% set morePosts = collections.postsByDate | relatedPosts(page.url, topics) %}
   {% if morePosts | length %}
     <div class="container mt-5 pt-4 border-top">
       <h2 class="h4 mb-4">News</h2>

--- a/content/news/2024-05-14-hello-scangov.md
+++ b/content/news/2024-05-14-hello-scangov.md
@@ -8,7 +8,7 @@ description: "A government digital experience monitor."
 #ogImageAlt: ""
 #img_caption: ""
 #img_link: 
-keywords:
+topics:
  - digital experience
  - government websites
  - government digital experience

--- a/content/news/2024-06-25-release-notes-06-2024.md
+++ b/content/news/2024-06-25-release-notes-06-2024.md
@@ -8,7 +8,7 @@ description: "ScanGov updates."
 #ogImageAlt: ""
 #img_caption: ""
 #img_link: 
-keywords:
+topics:
  - Government Experience Awards
  - GovX
  - Center for Digital Government

--- a/content/news/2024-10-17-new-gov-website-security grades-scores.md
+++ b/content/news/2024-10-17-new-gov-website-security grades-scores.md
@@ -8,7 +8,7 @@ description: "Scans include content security policy, HSTS, X-Content-Type-Option
 #ogImageAlt: ""
 #img_caption: ""
 #img_link: 
-keywords:
+topics:
  - digital experience
  - government websites
  - government digital experience

--- a/content/news/2025-02-12-welcome-aaron-hans.md
+++ b/content/news/2025-02-12-welcome-aaron-hans.md
@@ -8,7 +8,7 @@ description: "New ScanGov maintainer."
 #ogImageAlt: ""
 #img_caption: ""
 #img_link: 
-keywords:
+topics:
  - Aaron Hans
 ---
 

--- a/content/news/2025-04-06-government-experience-awards-2025.md
+++ b/content/news/2025-04-06-government-experience-awards-2025.md
@@ -11,10 +11,8 @@ ogImageAlt: "2025 Government Experience Awards"
 topics:
   - ScanGov
   - GovX
-keywords:
- - Government Experience Awards
- - GovX
- - Center for Digital Government
+  - Government Experience Awards
+  - Center for Digital Government
 ---
 
 [ScanGov](https://scangov.com) will again provide essential data support for e.Republic’s [Center for Digital Government](https://www.govtech.com/cdg)  **2025** [Government Experience Awards](https://www.govtech.com/cdg/government-experience), contributing critical quantitative metrics to the judging process.

--- a/content/news/2025-04-09-scangov-notes-2025-04-09.md
+++ b/content/news/2025-04-09-scangov-notes-2025-04-09.md
@@ -8,7 +8,7 @@ ogImage: posts/notes-og.png
 ogImageAlt: "File icon centered with ScanGov logo bottom right"
 img_caption: "File icon by Font Awesome"
 img_link: https://fontawesome.com
-keywords:
+topics:
  - digital experience
  - government websites
  - government digital experience

--- a/content/news/2025-04-21-scangov-map.md
+++ b/content/news/2025-04-21-scangov-map.md
@@ -8,7 +8,7 @@ ogImage: posts/scangov-map.png
 ogImageAlt: "Map of U.S. states color coded by government digital experience grade."
 img_caption: "Source: Project ScanGov"
 #img-link: 
-keywords:
+topics:
  - digital experience
  - government websites
  - government digital experience

--- a/content/news/2025-05-14-standards-for-government-digital-experience.md
+++ b/content/news/2025-05-14-standards-for-government-digital-experience.md
@@ -8,7 +8,7 @@ ogImage: posts/certificate-og.png
 ogImageAlt: "Certificate icon"
 img_caption: "Icon by Font Awesome"
 img_link: https://fontawesome.com/
-keywords:
+topics:
  - digital experience
  - government websites
  - government digital experience

--- a/content/news/2025-07-17-fcp-lcp-demo.md
+++ b/content/news/2025-07-17-fcp-lcp-demo.md
@@ -6,7 +6,7 @@ author: aaron-hans
 video: 6ElhrWOutL0
 eleventyComputed:
   permalink: /news/fcp-lcp-demo/
-keywords:
+topics:
   - performance
   - FCP
   - LCP

--- a/content/news/2025-07-17-ttfb-demo.md
+++ b/content/news/2025-07-17-ttfb-demo.md
@@ -6,7 +6,7 @@ author: aaron-hans
 video: ZqA12UyL3Bs
 eleventyComputed:
   permalink: /news/ttfb-demo/
-keywords:
+topics:
   - performance
   - TTFB
   - web vitals

--- a/content/news/2026-06-06-the-ai-development-boom-is-great.md
+++ b/content/news/2026-06-06-the-ai-development-boom-is-great.md
@@ -6,7 +6,7 @@ description: "AI-generated code has consistent quality gaps across accessibility
 eleventyExcludeFromCollections: true
 eleventyComputed:
   permalink: /news/ai-development-boom-automated-quality-checks/
-keywords:
+topics:
  - AI code quality
  - web standards
  - accessibility

--- a/content/news/_post-template.md
+++ b/content/news/_post-template.md
@@ -10,7 +10,7 @@ description: ""
 # img_caption: ""
 # img_link:
 # video: youtube-id-here
-keywords:
+topics:
   -
 ---
 


### PR DESCRIPTION
Both fed the same relatedPosts algorithm with no distinction, and keywords had no other consumer (the SEO keywords meta tag is driven by a separate, unrelated guidance data field). Standardizes on topics, matching the convention already used elsewhere in the site family.