### PR TITLE
Fix CSS inlining pipeline, nav active-state padding, heading order, a…

### DIFF
--- a/_data/people.json
+++ b/_data/people.json
@@ -1,38 +1,46 @@
 [
-    {
-      "name": "ScanGov",
-      "slug": "scangov",
-      "url": "https://scangov.com",
-      "linkedin": "https://linkedin.com/company/scangov",
-      "youtube": "https://youtube.com/@scangov",
-      "github": "https://github.com/scangov",
-      "discord": "https://discord.gg/EPCXEMAX5y",
-      "substack": "https://scangov.substack.com",
-      "rss": "https://scangov.com/news/feed.xml",
-      "hidden": true
-    },
-    {
-      "name": "Elias Fretwell",
-      "slug": "elias-fretwell",
-      "img": "elias-fretwell.jpg",
-      "github": "https://github.com/narlotl"
-    },
-    {
-      "name": "Luke Fretwell",
-      "slug": "luke-fretwell",
-      "img": "luke-fretwell.jpg",
-      "url": "https://lukefretwell.com",
-      "linkedin": "https://www.linkedin.com/in/lukefretwell",
-      "github": "https://github.com/lukefretwell",
-      "mastodon": "https://mastodon.social/@lukefretwell",
-      "bluesky": "https://lukefretwell.bsky.social/"
-    },
-    {
-      "name": "Aaron Hans",
-      "slug": "aaron-hans",
-      "img": "aaron-hans.jpg",
-      "linkedin": "https://www.linkedin.com/in/aaronhans/",
-      "github": "https://github.com/aaronhans",
-      "mastodon": "https://indieweb.social/@nopattern"
-    }
+  {
+    "name": "ScanGov",
+    "slug": "scangov",
+    "url": "https://scangov.com",
+    "description": "ScanGov is a digital experience monitor, fixer, and certifier.",
+    "linkedin": "https://linkedin.com/company/scangov",
+    "youtube": "https://youtube.com/@scangov",
+    "github": "https://github.com/scangov",
+    "discord": "https://discord.gg/EPCXEMAX5y",
+    "substack": "https://scangov.substack.com",
+    "rss": "https://scangov.com/news/feed.xml",
+    "hidden": true
+  },
+  {
+    "name": "Elias Fretwell",
+    "slug": "elias-fretwell",
+    "img": "elias-fretwell.jpg",
+    "title": "Co-founder",
+    "description": "Elias is a ScanGov co-founder.",
+    "url": "https://eliasfretwell.com",
+    "github": "https://github.com/narlotl"
+  },
+  {
+    "name": "Luke Fretwell",
+    "slug": "luke-fretwell",
+    "img": "luke-fretwell.jpg",
+    "title": "Co-founder",
+    "description": "Luke is a ScanGov co-founder.",
+    "url": "https://lukefretwell.com",
+    "linkedin": "https://www.linkedin.com/in/lukefretwell",
+    "github": "https://github.com/lukefretwell",
+    "mastodon": "https://mastodon.social/@lukefretwell",
+    "bluesky": "https://lukefretwell.bsky.social/"
+  },
+  {
+    "name": "Aaron Hans",
+    "slug": "aaron-hans",
+    "img": "aaron-hans.jpg",
+    "title": "Co-founder",
+    "description": "Aaron is a ScanGov co-founder.",
+    "linkedin": "https://www.linkedin.com/in/aaronhans/",
+    "github": "https://github.com/aaronhans",
+    "mastodon": "https://indieweb.social/@nopattern"
+  }
 ]

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -100,6 +100,7 @@
     <script type="application/ld+json">{{ schema | safe }}</script>
     {% endif %}
     {% include "favicon.html" %}
+    <link rel="preload" href="/assets/fonts/public-sans/ttf/PublicSans-Regular.ttf" as="font" type="font/ttf" crossorigin>
     {% include "style.html" %}
     <script>
         document.documentElement.setAttribute('data-bs-theme', window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');

--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -17,6 +17,7 @@
     <div class="container">
       <div class="row">
         <div class="col-12">
+          {% if breadcrumbParent or breadcrumbCurrent %}{% include "breadcrumb-default.html" %}{% endif %}
           {% if title %}
             <h1 class="display-5">{{ title }}</h1>
           {% endif %}

--- a/_includes/now_scanning_list.html
+++ b/_includes/now_scanning_list.html
@@ -20,9 +20,9 @@
         <div class="card position-relative">
           <div class="card-body py-5 d-flex flex-column align-items-center justify-content-center text-center">
             <i class="fa-solid fa-arrow-pointer fa-2x mb-3" aria-hidden="true"></i>
-            <h3 class="h4 mb-0">
+            <h2 class="h4 mb-0">
               <a href="/now-scanning/{{ item.title | slugify }}/" class="stretched-link">{{ item.title }}</a>
-            </h3>
+            </h2>
           </div>
         </div>
       </div>

--- a/_includes/style.html
+++ b/_includes/style.html
@@ -1,3 +1,1 @@
-<link rel="preload" href="/assets/bootstrap/css/bootstrap.min.css" as="style">
-<link rel="stylesheet" href="/assets/bootstrap/css/bootstrap.min.css">
-<link href="/css/scangov.css" rel="stylesheet">
+<!--put inlined css here-->

--- a/content/news/2026-07-14-scangov-2026-government-experience-awards.md
+++ b/content/news/2026-07-14-scangov-2026-government-experience-awards.md
@@ -1,7 +1,7 @@
 ---
-date: 2026-07-10
+date: 2026-07-14
 # modified: YYYY-MM-DD
-author: ScanGov
+author: scangov
 title: "ScanGov to support judging for 2026 Government Experience Awards"
 description: "Will provide website digital experience data to the Center for Digital Government’s annual GovX Awards program."
 # ogImage: posts/.png

--- a/content/news/news.11tydata.json
+++ b/content/news/news.11tydata.json
@@ -2,6 +2,9 @@
     "layout": "layouts/post.html",
     "isPost": true,
     "author": "scangov",
+    "breadcrumbParent": [
+        { "url": "/news/", "title": "News" }
+    ],
     "eleventyComputed": {
         "permalink": "/news/{{ title | lower | replace(' ', '-') | replace('.', '-') | replace('(', '') | replace(')', '') }}/index.html"
     },

--- a/content/people.html
+++ b/content/people.html
@@ -29,30 +29,31 @@ description: "The humans of ScanGov."
                     {{ item.name }}
                   {% endif %}
                 </h2>
+                {% if item.title %}<p class="text-body-secondary small mb-3">{{ item.title }}</p>{% endif %}
                 <div class="social fs-5 position-relative" style="z-index:2">
                   {% if item.url %}
-                    <a href="{{ site.baseurl }}{{ item.url }}" target="_blank" rel="noopener">
-                      <i class="fa-solid fa-link" aria-label="Website"></i>
+                    <a href="{{ site.baseurl }}{{ item.url }}" target="_blank" rel="noopener" aria-label="Website">
+                      <i class="fa-solid fa-link" aria-hidden="true"></i>
                     </a>
                   {% endif %}
                   {% if item.linkedin %}
-                    <a href="{{ item.linkedin }}" target="_blank" rel="noopener">
-                      <i class="fa-brands fa-linkedin" aria-label="LinkedIn"></i>
+                    <a href="{{ item.linkedin }}" target="_blank" rel="noopener" aria-label="LinkedIn">
+                      <i class="fa-brands fa-linkedin" aria-hidden="true"></i>
                     </a>
                   {% endif %}
                   {% if item.github %}
-                    <a href="{{ item.github }}" target="_blank" rel="noopener">
-                      <i class="fa-brands fa-github" aria-label="GitHub"></i>
+                    <a href="{{ item.github }}" target="_blank" rel="noopener" aria-label="GitHub">
+                      <i class="fa-brands fa-github" aria-hidden="true"></i>
                     </a>
                   {% endif %}
                   {% if item.mastodon %}
-                    <a href="{{ item.mastodon }}" target="_blank" rel="noopener">
-                      <i class="fa-brands fa-mastodon" aria-label="Mastodon"></i>
+                    <a href="{{ item.mastodon }}" target="_blank" rel="noopener" aria-label="Mastodon">
+                      <i class="fa-brands fa-mastodon" aria-hidden="true"></i>
                     </a>
                   {% endif %}
                   {% if item.bluesky %}
-                    <a href="{{ item.bluesky }}" target="_blank" rel="noopener">
-                      <i class="fa-brands fa-bluesky" aria-label="Bluesky"></i>
+                    <a href="{{ item.bluesky }}" target="_blank" rel="noopener" aria-label="Bluesky">
+                      <i class="fa-brands fa-bluesky" aria-hidden="true"></i>
                     </a>
                   {% endif %}
                 </div>

--- a/content/people/person.html
+++ b/content/people/person.html
@@ -8,6 +8,7 @@ pagination:
   addAllPagesToCollections: true
 eleventyComputed:
   title: "{{ person.name }}"
+  description: "{{ person.description }}"
   permalink: "/people/{{ person.slug }}/"
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "npm run concat:css && npx @11ty/eleventy --quiet",
 		"build-ghpages": "npm run concat:css && npx @11ty/eleventy --pathprefix=/scangov/",
-		"concat:css": "cat public/css/scangov.css public/assets/bootstrap/css/bootstrap.css public/assets/font-awesome/css/all.css > scripts/bundle.css",
+		"concat:css": "cat public/assets/bootstrap/css/bootstrap.css public/assets/font-awesome/css/all.css public/css/scangov.css > scripts/bundle.css",
 		"start": "node scripts/getcomponents.js && npm run concat:css && npx @11ty/eleventy --serve --quiet"
 	},
 	"dependencies": {

--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -4,49 +4,49 @@
 
 @font-face {
     font-family: "Public Sans ExtraBold";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-ExtraBold.ttf") format("truetype");
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-ExtraBold.ttf") format("truetype");
     font-display: swap;
 }
 
 @font-face {
     font-family: "Public Sans Bold";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-Bold.ttf") format("truetype");
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-Bold.ttf") format("truetype");
     font-display: swap;
 }
 
 @font-face {
     font-family: "Public Sans Regular";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-Regular.ttf") format("truetype");
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-Regular.ttf") format("truetype");
     font-display: swap;
 }
 
 @font-face {
     font-family: "Public Sans Light";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-Light.ttf") format("truetype");
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-Light.ttf") format("truetype");
     font-display: swap;
 }
 
 @font-face {
     font-family: "Public Sans Thin";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-Thin.ttf") format("truetype");
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-Thin.ttf") format("truetype");
     font-display: swap;
 }
 
 @font-face {
     font-family: "JetBrains Mono Regular";
-    src: local("JetBrains Mono"), url("../assets/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf") format("truetype");
+    src: local("JetBrains Mono"), url("/assets/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf") format("truetype");
     font-display: swap;
 }
 
 @font-face {
     font-family: "JetBrains Mono Medium";
-    src: url("../assets/fonts/jetbrains-mono/JetBrainsMono-Medium.ttf") format("truetype");
+    src: url("/assets/fonts/jetbrains-mono/JetBrainsMono-Medium.ttf") format("truetype");
     font-display: swap;
 }
 
 @font-face {
     font-family: "JetBrains Mono ExtraBold";
-    src: url("../assets/fonts/jetbrains-mono/JetBrainsMono-ExtraBold.ttf") format("truetype");
+    src: url("/assets/fonts/jetbrains-mono/JetBrainsMono-ExtraBold.ttf") format("truetype");
     font-display: swap;
 }
 
@@ -477,6 +477,11 @@ button:not(.card *) {
 a.list-group-item {
     color: var(--bs-body-color) !important;
     font-family: "Public Sans Regular", sans-serif !important;
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
+}
+
+.navbar-nav .nav-link.active {
     padding-top: 0.65rem;
     padding-bottom: 0.65rem;
 }

--- a/scripts/bundle.css
+++ b/scripts/bundle.css
@@ -1,3140 +1,4 @@
-/* This file is maintaned in https://github.com/ScanGov/components and copied to multiple projects during startup */
-
-/* Fonts */
-
-@font-face {
-    font-family: "Public Sans ExtraBold";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-ExtraBold.ttf") format("truetype");
-    font-display: swap;
-}
-
-@font-face {
-    font-family: "Public Sans Bold";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-Bold.ttf") format("truetype");
-    font-display: swap;
-}
-
-@font-face {
-    font-family: "Public Sans Regular";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-Regular.ttf") format("truetype");
-    font-display: swap;
-}
-
-@font-face {
-    font-family: "Public Sans Light";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-Light.ttf") format("truetype");
-    font-display: swap;
-}
-
-@font-face {
-    font-family: "Public Sans Thin";
-    src: url("../assets/fonts/public-sans/ttf/PublicSans-Thin.ttf") format("truetype");
-    font-display: swap;
-}
-
-@font-face {
-    font-family: "JetBrains Mono Regular";
-    src: local("JetBrains Mono"), url("../assets/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf") format("truetype");
-    font-display: swap;
-}
-
-@font-face {
-    font-family: "JetBrains Mono Medium";
-    src: url("../assets/fonts/jetbrains-mono/JetBrainsMono-Medium.ttf") format("truetype");
-    font-display: swap;
-}
-
-@font-face {
-    font-family: "JetBrains Mono ExtraBold";
-    src: url("../assets/fonts/jetbrains-mono/JetBrainsMono-ExtraBold.ttf") format("truetype");
-    font-display: swap;
-}
-
-/* Dark mode (default) */
-
-:root, [data-bs-theme=dark] {
-    color-scheme: dark;
-    --bs-primary: #4FB8F0;
-    --bs-primary-rgb: 79, 184, 240;
-    --bs-primary-text: #13171f;
-    --bs-body-color: #fff;
-    --bs-body-color-rgb: 255, 255, 255;
-    --bs-body-bg: #13171f;
-    --bs-body-bg-rgb: 19, 23, 31;
-    --bs-body-secondary-bg: #0f1218;
-    --bs-link-color: #4FB8F0;
-    --bs-link-color-rgb: 79, 184, 240;
-    --bs-link-hover-color: var(--bs-link-color);
-    --bs-link-hover-color-rgb: 79, 184, 240;
-    --bs-link-hover-decoration: none;
-    --bs-highlight-bg: var(--bs-primary);
-    --bs-highlight-color: var(--bs-primary-text);
-    --bs-selection-bg: var(--bs-primary);
-    --bs-selection-color: var(--bs-primary-text);
-    --bs-btn-primary: var(--bs-primary);
-    --bs-btn-primary-color: var(--bs-primary-text);
-    --bs-btn-primary-border-color: var(--bs-primary);
-    --bs-btn-primary-focus-shadow-rgb: 79, 184, 240;
-    --bs-btn-primary-active-shadow-rgb: 79, 184, 240;
-    --bs-btn-primary-active-color: var(--bs-primary-text);
-    --bs-btn-primary-active-bg: var(--bs-primary);
-    --bs-btn-primary-bg: var(--bs-primary);
-    --bs-btn-bg: var(--bs-primary);
-    --bs-btn-border-color: var(--bs-primary);
-    --bs-btn-color: var(--bs-primary-text);
-    --bs-btn-hover-bg: var(--bs-primary);
-    --bs-btn-hover-border-color: var(--bs-primary);
-    --bs-btn-hover-color: var(--bs-primary-text);
-    --bs-nav-link-color: var(--bs-body-color);
-    --bs-nav-link-hover-color: var(--bs-link-color);
-    --bs-border-color: #252f3e;
-    --bs-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
-    --bs-card-shadow: var(--bs-shadow);
-    --bs-box-shadow: var(--bs-shadow);
-    --bs-box-shadow-md: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.5);
-    --bs-secondary: var(--bs-body-color);
-    --bs-text-secondary: var(--bs-secondary);
-    --bs-badge-bg: var(--bs-primary);
-    --bs-badge-font-weight: 300;
-    --bs-border-radius-sm: .25rem;
-    /* WCAG 2.2 AA: #face00 on #13171f = 11.87:1 ✓ */
-    --bs-text-bg-primary: #face00;
-    --bs-info-text-emphasis: var(--bs-body-color);
-    --bs-info-bg-subtle: var(--bs-body-secondary-bg);
-    --bs-info-border-subtle: var(--bs-border-color);
-    --bs-primary-bg-subtle: #0a1929;
-    --bs-primary-border-subtle: #1d4ed8;
-    --bs-primary-text-emphasis: #93c5fd;
-    --bs-text-muted: var(--bs-body-color);
-    --bs-font-monospace: "JetBrains Mono Regular", monospace;
-    --bs-font-light: "Public Sans Light", sans-serif;
-    --bs-font-bold: "Public Sans Bold", sans-serif;
-    --bs-font-regular: "Public Sans Regular", sans-serif;
-    --bs-font-sans-serif: "Public Sans Regular", sans-serif;
-    --bs-text-opacity: .5;
-    --bs-emphasis-color: var(--bs-body-color);
-    --bs-form-control-color: var(--bs-body-color);
-    --bs-form-control-bg: var(--bs-body-bg);
-    --bs-form-control-border-color: var(--bs-border-color);
-    --bs-form-control-focus-border-color: var(--bs-primary);
-    --bs-form-control-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
-    --bs-form-control-focus-color: var(--bs-body-color);
-    --bs-card-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
-    /* Status colors */
-    --bs-success: #70e17b;
-    --bs-bg-success: #70e17b;
-    --bs-bg-success-rgb: 112, 225, 123;
-    --bs-border-success: #70e17b;
-    --bs-warning: #face00;
-    --bs-text-warning: #000000;
-    --bs-bg-warning: #face00;
-    --bs-bg-warning-rgb: 250, 206, 0;
-    --bs-border-warning: #face00;
-    --bs-danger: #e41d3d;
-    --bs-text-danger: #ffffff;
-    --bs-bg-danger: #e41d3d;
-    --bs-bg-danger-rgb: 228, 29, 61;
-    --bs-border-danger: #e41d3d;
-}
-
-/* Light mode */
-
-[data-bs-theme=light] {
-    color-scheme: light;
-    --bs-primary: #2563eb;
-    --bs-primary-rgb: 37, 99, 235;
-    --bs-primary-text: #ffffff;
-    --bs-body-color: #13171f;
-    --bs-body-color-rgb: 19, 23, 31;
-    --bs-body-bg: #ffffff;
-    --bs-body-bg-rgb: 255, 255, 255;
-    --bs-body-secondary-bg: #f4f6f9;
-    /* WCAG 2.2 AA: #2563eb on #fff = 4.66:1 ✓ */
-    --bs-link-color: #2563eb;
-    --bs-link-color-rgb: 37, 99, 235;
-    --bs-link-hover-color: var(--bs-link-color);
-    --bs-link-hover-color-rgb: 37, 99, 235;
-    --bs-link-hover-decoration: none;
-    --bs-highlight-bg: var(--bs-primary);
-    --bs-highlight-color: var(--bs-primary-text);
-    --bs-selection-bg: var(--bs-primary);
-    --bs-selection-color: var(--bs-primary-text);
-    --bs-btn-primary: var(--bs-primary);
-    --bs-btn-primary-color: var(--bs-primary-text);
-    --bs-btn-primary-border-color: var(--bs-primary);
-    --bs-btn-primary-focus-shadow-rgb: 37, 99, 235;
-    --bs-btn-primary-active-shadow-rgb: 37, 99, 235;
-    --bs-btn-primary-active-color: var(--bs-primary-text);
-    --bs-btn-primary-active-bg: var(--bs-primary);
-    --bs-btn-primary-bg: var(--bs-primary);
-    --bs-btn-bg: var(--bs-primary);
-    --bs-btn-border-color: var(--bs-primary);
-    --bs-btn-color: var(--bs-primary-text);
-    --bs-btn-hover-bg: var(--bs-primary);
-    --bs-btn-hover-border-color: var(--bs-primary);
-    --bs-btn-hover-color: var(--bs-primary-text);
-    --bs-nav-link-color: var(--bs-body-color);
-    --bs-nav-link-hover-color: var(--bs-link-color);
-    --bs-border-color: #d5dce8;
-    --bs-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.06);
-    --bs-card-shadow: var(--bs-shadow);
-    --bs-box-shadow: var(--bs-shadow);
-    --bs-box-shadow-md: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.15);
-    --bs-secondary: var(--bs-body-color);
-    --bs-text-secondary: var(--bs-secondary);
-    --bs-badge-bg: var(--bs-primary);
-    --bs-badge-font-weight: 300;
-    --bs-border-radius-sm: .25rem;
-    /* WCAG 2.2 AA: #fff on #2563eb = 4.66:1 ✓ */
-    --bs-text-bg-primary: #2563eb;
-    --bs-info-text-emphasis: var(--bs-body-color);
-    --bs-info-bg-subtle: var(--bs-body-secondary-bg);
-    --bs-info-border-subtle: var(--bs-border-color);
-    --bs-primary-bg-subtle: #dbeafe;
-    --bs-primary-border-subtle: #3b82f6;
-    --bs-primary-text-emphasis: #1e3a8a;
-    /* WCAG 2.2 AA: #4a5568 on #fff = 7.53:1 ✓ */
-    --bs-text-muted: #4a5568;
-    --bs-text-opacity: .5;
-    --bs-emphasis-color: var(--bs-body-color);
-    --bs-form-control-color: var(--bs-body-color);
-    --bs-form-control-bg: var(--bs-body-bg);
-    --bs-form-control-border-color: var(--bs-border-color);
-    --bs-form-control-focus-border-color: var(--bs-primary);
-    --bs-form-control-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
-    --bs-form-control-focus-color: var(--bs-body-color);
-    --bs-card-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
-    /* font vars, status colors inherited from :root */
-}
-
-/* Status badge overrides */
-
-/* WCAG 2.2 AA: #13171f on #70e17b = 8.19:1 ✓ */
-.text-bg-success {
-    color: #13171f !important;
-    background-color: #70e17b !important;
-}
-
-/* WCAG 2.2 AA: #000 on #face00 = 15.18:1 ✓ */
-.text-bg-warning {
-    color: #000000 !important;
-    background-color: #face00 !important;
-}
-
-/* WCAG 2.2 AA: #fff on #e41d3d = 4.73:1 ✓ */
-.text-bg-danger {
-    color: #ffffff !important;
-    background-color: #e41d3d !important;
-}
-
-.text-bg-primary {
-    background-color: var(--bs-text-bg-primary) !important;
-    color: var(--bs-body-bg) !important;
-}
-
-/* Footer */
-
-footer a:hover {
-    color: var(--bs-link-color) !important;
-    text-decoration: underline;
-}
-
-footer p.small a {
-    text-decoration: underline;
-}
-
-footer p.small a:hover {
-    text-decoration: none;
-}
-
-/* Theme-dependent: logo/image invert */
-
-:root body footer img,
-:root body ul.navbar-nav img,
-[data-bs-theme=dark] body footer img,
-[data-bs-theme=dark] body ul.navbar-nav img {
-    filter: invert(1);
-}
-
-[data-bs-theme=light] body footer img,
-[data-bs-theme=light] body ul.navbar-nav img {
-    filter: none;
-}
-
-/* Theme-dependent: navbar toggler icon */
-
-[data-bs-theme="light"] .navbar-toggler-icon {
-    --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2819, 23, 31, 1%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-}
-
-[data-bs-theme="dark"] .navbar-toggler-icon {
-    --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 1%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-}
-
-/* Theme-dependent: text-secondary */
-
-.text-secondary {
-    color: rgba(19, 23, 31, var(--bs-text-opacity)) !important;
-}
-
-[data-bs-theme=dark] .text-secondary {
-    color: rgba(255, 255, 255, var(--bs-text-opacity)) !important;
-}
-
-/* General */
-
-blockquote {
-    padding: 1rem 1rem .5rem 1rem;
-    margin: 1rem 0 1rem 0;
-    border-left: 0.25rem solid var(--bs-border-color);
-    font-size: 1.25rem;
-}
-
-.text-muted {
-    color: var(--bs-body-color) !important;
-}
-
-body {
-    color: var(--bs-body-color);
-    background-color: var(--bs-body-bg) !important;
-    font-family: var(--bs-font-sans-serif);
-    line-height: 1.5;
-}
-
-strong {
-    font-family: var(--bs-font-bold);
-}
-
-.display-4, .display-5, .display-6 {
-    text-wrap: balance;
-}
-
-#main-content>.container {
-    margin-top: 1.5rem;
-}
-
-.navbar-brand,
-h1, h2, h3, h4, h5, h6,
-.h1, .h2, .h3, .h4, .h5, .h6,
-.display-1, .display-2, .display-3, .display-4 {
-    font-family: var(--bs-font-bold);
-    letter-spacing: -.01rem;
-}
-
-body.docs h2,
-body.page h2,
-body.post h2,
-body.default h2 {
-    margin-bottom: 1rem;
-    margin-top: 3rem;
-}
-
-body.docs h3,
-body.page h3,
-body.post h3,
-body.default h3 {
-    margin-bottom: 0.75rem;
-    margin-top: 2.5rem;
-}
-
-body.docs h4,
-body.page h4,
-body.post h4,
-body.default h4,
-body.docs h5,
-body.page h5,
-body.post h5,
-body.default h5,
-body.docs h6,
-body.page h6,
-body.post h6,
-body.default h6 {
-    margin-bottom: 0.5rem;
-    margin-top: 2rem;
-}
-
-/* Alert headings */
-
-.alert h1,
-.alert h2,
-.alert h3,
-.alert h4,
-.alert h5,
-.alert h6 {
-    margin-top: 0.75rem;
-    margin-bottom: 0.75rem;
-}
-
-/* Lead */
-
-.lead {
-    font-family: var(--bs-font-regular) !important;
-    font-size: 1.25rem;
-    font-weight: 300;
-    color: var(--bs-body-color);
-}
-
-/* Selection */
-
-::selection {
-    background-color: var(--bs-selection-bg);
-    color: var(--bs-selection-color);
-}
-
-/* Accessibility */
-
-/* Focus indicators (WCAG 2.4.7, 2.4.11) */
-:focus-visible {
-    outline: 3px solid var(--bs-link-color);
-    outline-offset: 2px;
-    border-radius: 2px;
-}
-
-/* Remove outline on mouse/touch click, keep for keyboard (WCAG 2.4.7) */
-:focus:not(:focus-visible) {
-    outline: none;
-}
-
-/* Minimum touch target size (WCAG 2.5.8) — exclude card children to avoid layout shift */
-a:not(.card):not(.card *):not(.stretched-link),
-button:not(.card *) {
-    min-height: 24px;
-    min-width: 24px;
-}
-
-/* Reduced motion (WCAG 2.3.3) */
-@media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
-    }
-}
-
-/* High contrast mode (WCAG 1.4.11) */
-@media (forced-colors: active) {
-    * {
-        forced-color-adjust: auto;
-    }
-}
-
-/* Skip link — visible on focus for keyboard users (WCAG 2.4.1) */
-.skip-link {
-    position: absolute;
-    top: -100%;
-    left: 0;
-}
-
-.skip-link:focus {
-    top: 0;
-}
-
-/* Navbar */
-
-#logo {
-    max-width: 35px;
-    width: 100%;
-    height: 100%;
-}
-
-.navbar {
-    box-shadow: var(--bs-shadow);
-    transition: box-shadow 0.25s ease;
-    --bs-navbar-padding-y: 0.5rem;
-    --bs-navbar-padding-x: 0;
-    --bs-nav-link-padding-y: 0.5rem;
-    --bs-nav-link-padding-x: 1rem;
-    --bs-nav-link-font-size: 1.1em;
-}
-
-.navbar-brand {
-    font-family: var(--bs-font-bold);
-    color: var(--bs-body-color) !important;
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-}
-
-.navbar-brand>svg {
-    fill: var(--bs-body-color) !important;
-}
-
-.navbar-brand:hover {
-    color: var(--bs-link-color) !important;
-}
-
-.navbar-brand:hover>svg {
-    fill: var(--bs-link-color) !important;
-}
-
-.navbar-toggler-icon {
-    color: var(--bs-body-color) !important;
-}
-
-.navbar-nav,
-.navbar-nav .nav-link:not(.active),
-a.list-group-item {
-    color: var(--bs-body-color) !important;
-    font-family: "Public Sans Regular", sans-serif !important;
-    padding-top: 0.65rem;
-    padding-bottom: 0.65rem;
-}
-
-.nav-link {
-    font-family: "Public Sans Regular", sans-serif !important;
-}
-
-.navbar-nav .nav-link:not(.active):hover,
-a.list-group-item:hover {
-    color: var(--bs-link-color) !important;
-}
-
-a.list-group-item:hover {
-    background-color: var(--bs-body-secondary-bg);
-}
-
-.border-end {
-    box-shadow: var(--bs-shadow);
-}
-
-/* Social links */
-
-.social a, .social a:visited {
-    color: var(--bs-body-color);
-    display: inline-block;
-    margin-right: .75rem;
-}
-
-.social a:hover {
-    color: var(--bs-link-color);
-}
-
-/* External link icon (post/page content) */
-
-.post-content a[href^="http"]:not([href^="https://scangov.org"]):not([href^="https://standards.scangov.org"]):not([href^="https://scangov.com"]):not([href^="https://my.scangov.com"]):not([href^="https://data.scangov.org"]):not([href^="http://localhost:4000/"]):not([href^="https://docs.scangov.org"])::after,
-.page-content a[href^="http"]:not([href^="https://scangov.org"]):not([href^="https://standards.scangov.org"]):not([href^="https://scangov.com"]):not([href^="https://my.scangov.com"]):not([href^="https://data.scangov.org"]):not([href^="http://localhost:4000/"]):not([href^="https://docs.scangov.org"])::after {
-    content: '';
-    display: inline-block;
-    width: 0.65em;
-    height: 0.65em;
-    margin-left: 0.25em;
-    vertical-align: text-top;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%237efbe1' d='M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6l0-128c0-17.7-14.3-32-32-32L352 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-size: contain;
-}
-
-[data-bs-theme=light] .post-content a[href^="http"]:not([href^="https://scangov.org"]):not([href^="https://standards.scangov.org"]):not([href^="https://scangov.com"]):not([href^="https://my.scangov.com"]):not([href^="https://data.scangov.org"]):not([href^="http://localhost:4000/"]):not([href^="https://docs.scangov.org"])::after,
-[data-bs-theme=light] .page-content a[href^="http"]:not([href^="https://scangov.org"]):not([href^="https://standards.scangov.org"]):not([href^="https://scangov.com"]):not([href^="https://my.scangov.com"]):not([href^="https://data.scangov.org"]):not([href^="http://localhost:4000/"]):not([href^="https://docs.scangov.org"])::after {
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%230d7a6e' d='M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6l0-128c0-17.7-14.3-32-32-32L352 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z'/%3E%3C/svg%3E");
-}
-
-.social a::after {
-    display: none !important;
-}
-
-/* Breadcrumb */
-
-.breadcrumb-item, .breadcrumb-item a, .breadcrumb-item a:visited {
-    color: var(--bs-link-color);
-    font-family: var(--bs-font-monospace);
-    text-decoration: none;
-}
-
-.breadcrumb-profile .breadcrumb-item,
-.breadcrumb-profile .breadcrumb-item a,
-.breadcrumb-profile .breadcrumb-item a:visited {
-    font-size: 1.2rem;
-}
-
-.breadcrumb-item a:hover {
-    text-decoration: underline;
-    color: var(--bs-link-color);
-}
-
-.bc-sep {
-    color: white;
-}
-
-.breadcrumb-item a.bc-org,
-.breadcrumb-item a.bc-org:visited {
-    color: var(--bs-link-color);
-}
-
-.breadcrumb-item a.bc-domain,
-.breadcrumb-item a.bc-domain:visited,
-.breadcrumb-item a.bc-org-current,
-.breadcrumb-item a.bc-org-current:visited {
-    color: white;
-}
-
-[data-bs-theme=light] .bc-sep {
-    color: var(--bs-body-color);
-}
-
-[data-bs-theme=light] .breadcrumb-item a.bc-org,
-[data-bs-theme=light] .breadcrumb-item a.bc-org:visited {
-    color: var(--bs-link-color);
-}
-
-[data-bs-theme=light] .breadcrumb-item a.bc-domain,
-[data-bs-theme=light] .breadcrumb-item a.bc-domain:visited,
-[data-bs-theme=light] .breadcrumb-item a.bc-org-current,
-[data-bs-theme=light] .breadcrumb-item a.bc-org-current:visited {
-    color: var(--bs-body-color);
-}
-
-/* Default (Bootstrap-style) breadcrumb — no bold, standard colors */
-.breadcrumb-default .breadcrumb-item,
-.breadcrumb-default .breadcrumb-item a,
-.breadcrumb-default .breadcrumb-item a:visited {
-    font-family: inherit;
-}
-
-.breadcrumb-default .breadcrumb-item.active {
-    color: var(--bs-secondary-color);
-}
-
-/* Links / Buttons */
-
-a:hover {
-    text-decoration: var(--bs-link-hover-decoration);
-    color: var(--bs-link-hover-color);
-}
-
-.btn-primary,
-.btn-primary:visited {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-radius: var(--bs-border-radius);
-    border: 1px solid var(--bs-primary) !important;
-    box-shadow: var(--bs-shadow);
-    cursor: pointer;
-    font-family: var(--bs-font-bold);
-    padding: 0.5rem 0.875rem;
-    transition: filter 0.25s ease, box-shadow 0.25s ease;
-}
-
-.btn-primary.btn-lg {
-    padding: 0.625rem 1.25rem;
-}
-
-.btn-primary.btn-sm {
-    padding: 0.3rem 0.6rem;
-}
-
-a.btn-primary-outline,
-button.btn-primary-outline {
-    background-color: var(--bs-body-bg);
-    color: var(--bs-body-color);
-    border-radius: var(--bs-border-radius-sm);
-    border: 1px solid var(--bs-border-color);
-    box-shadow: var(--bs-shadow);
-    cursor: pointer;
-    font-family: var(--bs-font-sans-serif);
-    padding: 0.5rem 0.875rem;
-    transition: filter 0.25s ease, box-shadow 0.25s ease;
-}
-
-button.btn-primary-outline:hover,
-button.btn-primary-outline:focus {
-    color: var(--bs-body-bg) !important;
-}
-
-.btn-primary-outline:hover i,
-.btn-primary-outline:hover svg {
-    color: inherit !important;
-}
-
-.btn.btn-outline-primary {
-    --bs-btn-color: var(--bs-body-color);
-    --bs-btn-border-color: var(--bs-border-color);
-    --bs-btn-hover-color: var(--bs-body-bg);
-    --bs-btn-hover-bg: var(--bs-body-color);
-    --bs-btn-hover-border-color: var(--bs-body-color);
-    --bs-btn-active-color: var(--bs-body-bg);
-    --bs-btn-active-bg: var(--bs-body-color);
-    --bs-btn-active-border-color: var(--bs-body-color);
-    padding: 0.5rem 0.875rem;
-}
-
-.btn.btn-outline-primary.btn-lg {
-    padding: 0.625rem 1.25rem;
-}
-
-.btn.btn-outline-primary.btn-sm {
-    padding: 0.3rem 0.6rem;
-}
-
-.btn.btn-outline-primary:not(.btn-lg) {
-    margin-top: 1rem;
-}
-
-.btn.btn-outline-primary i,
-.btn.btn-outline-primary svg {
-    color: inherit !important;
-}
-
-.btn.btn-outline-primary .fa-sitemap {
-    color: #ffbc78 !important;
-}
-
-.btn.btn-outline-primary:hover .fa-sitemap,
-.btn.btn-outline-primary:focus .fa-sitemap {
-    color: inherit !important;
-}
-
-.btn[download] {
-    margin-right: 0.5rem;
-    margin-bottom: 0.5rem;
-}
-
-.feedback {
-    opacity: 0;
-    pointer-events: none;
-    visibility: hidden;
-    background-color: var(--bs-primary);
-    color: var(--bs-primary-text) !important;
-    border-radius: var(--bs-border-radius);
-    border: 1px solid var(--bs-primary);
-    box-shadow: var(--bs-shadow);
-    cursor: pointer;
-    font-family: var(--bs-font-bold);
-    position: fixed;
-    bottom: 1rem;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 1000;
-    text-decoration: none;
-    transition: opacity 0.25s ease, visibility 0.25s ease, filter 0.25s ease, box-shadow 0.25s ease;
-}
-
-.feedback.is-visible {
-    opacity: 1;
-    pointer-events: auto;
-    visibility: visible;
-}
-
-.btn-primary i, .btn-primary svg,
-.feedback i, .feedback svg {
-    color: inherit !important;
-    transition: filter 0.25s ease;
-}
-
-.btn-primary:hover, .btn-primary:focus,
-.feedback:hover, .feedback:focus {
-    filter: brightness(1.3);
-    box-shadow: var(--bs-box-shadow-md);
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-}
-
-a.btn-primary-outline:not(.active):hover,
-.btn-primary-outline:not(.active):hover,
-a.btn-primary-outline:not(.active):focus,
-a.btn-primary-outline.active,
-.btn-primary-outline.active {
-    filter: brightness(1.3);
-    box-shadow: var(--bs-box-shadow-md);
-    border: 1px solid var(--bs-border-color);
-}
-
-@media (max-width: 767.98px) {
-    .feedback {
-        font-size: 0.875rem;
-    }
-}
-
-/* js-triggered Bootstrap classes */
-.btn-check:checked+.btn,
-.btn.active:not(.nav-link),
-.btn.show,
-.btn:first-child:active,
-:not(.btn-check)+.btn:active {
-    color: var(--bs-btn-active-color);
-    background-color: var(--bs-btn-active-bg);
-    border-color: var(--bs-btn-active-border-color);
-}
-
-/* Nav pills */
-
-.nav-pills {
-    --bs-nav-pills-link-active-bg: var(--bs-primary);
-    --bs-nav-link-hover-border-color: #1a2130;
-}
-
-[data-bs-theme=light] .nav-pills {
-    --bs-nav-link-hover-border-color: #b0bac8;
-}
-
-.nav-pills .nav-link svg {
-    flex-shrink: 0;
-    width: 1em;
-    height: 1em;
-}
-
-.nav-pills .nav-link {
-    border: 1px solid var(--bs-border-color);
-    box-shadow: var(--bs-shadow);
-    font-family: "Public Sans Regular", sans-serif !important;
-    color: var(--bs-body-color);
-    background-color: var(--bs-body-bg);
-    transition: filter 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
-    margin-top: 0.35rem;
-    margin-bottom: 0.35rem;
-    display: inline-flex !important;
-    align-items: center;
-    width: auto;
-    flex-shrink: 0;
-}
-
-.nav-pills .nav-link:not(.active):hover,
-.nav-pills a.btn-primary-outline:not(.active):hover {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-    box-shadow: var(--bs-shadow);
-}
-
-.nav-pills .nav-link:not(.active):hover i,
-.nav-pills .nav-link:not(.active):hover svg {
-    color: var(--bs-primary-text) !important;
-}
-
-.nav-pills .nav-link:not(.active):hover svg path {
-    fill: var(--bs-primary-text) !important;
-}
-
-.nav-pills .nav-link.active i,
-.nav-pills .nav-link.active:hover i,
-.nav-pills .nav-link.active svg,
-.nav-pills .nav-link.active:hover svg {
-    color: var(--bs-primary-text) !important;
-}
-
-/* Nav pills active — var(--bs-primary-text) on var(--bs-primary) (both themes) */
-.nav-pills .nav-link.active,
-.nav-pills .nav-link.active:focus,
-.nav-pills a.btn-primary-outline.active,
-.nav-pills a.btn-primary-outline.active:focus,
-[data-bs-theme=light] .nav-pills .nav-link.active,
-[data-bs-theme=light] .nav-pills .nav-link.active:focus,
-[data-bs-theme=light] .nav-pills a.btn-primary-outline.active,
-[data-bs-theme=light] .nav-pills a.btn-primary-outline.active:focus {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-    box-shadow: var(--bs-shadow);
-}
-
-.nav-pills .nav-link.active:hover,
-.nav-pills a.btn-primary-outline.active:hover,
-[data-bs-theme=light] .nav-pills .nav-link.active:hover,
-[data-bs-theme=light] .nav-pills a.btn-primary-outline.active:hover {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-    filter: brightness(1.3);
-    box-shadow: var(--bs-box-shadow-md);
-}
-
-.nav-pills .fa-bars-progress {
-    color: var(--bs-primary) !important;
-}
-
-.nav-pills .fa-certificate {
-    color: #ffbe2e !important;
-}
-
-.nav-pills .fa-diagram-project {
-    color: #7efbe1 !important;
-}
-
-.nav-pills .fa-file-lines {
-    color: #a8f2ff !important;
-}
-
-.nav-pills .fa-database {
-    color: #a8f5d5 !important;
-}
-
-.nav-pills .nav-link.active i,
-.nav-pills .nav-link.active svg,
-.nav-pills a.btn-primary-outline.active i,
-.nav-pills a.btn-primary-outline.active svg,
-[data-bs-theme=light] .nav-pills .nav-link.active i,
-[data-bs-theme=light] .nav-pills .nav-link.active svg,
-[data-bs-theme=light] .nav-pills a.btn-primary-outline.active i,
-[data-bs-theme=light] .nav-pills a.btn-primary-outline.active svg {
-    color: var(--bs-primary-text) !important;
-}
-
-.nav-pills .active {
-    --bs-link-color: var(--bs-body-bg);
-}
-
-/* Profile leftnav active state — same treatment as filter pills */
-.list-group-item.active,
-.list-group-item.active:focus,
-[data-bs-theme=light] .list-group-item.active,
-[data-bs-theme=light] .list-group-item.active:focus {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-}
-
-.list-group-item.active:hover,
-[data-bs-theme=light] .list-group-item.active:hover {
-    color: var(--bs-primary-text) !important;
-    filter: brightness(1.3);
-}
-
-.list-group-item.active i,
-.list-group-item.active svg,
-[data-bs-theme=light] .list-group-item.active i,
-[data-bs-theme=light] .list-group-item.active svg {
-    color: var(--bs-primary-text) !important;
-}
-
-/* Topic filter pills (standards/guidance switcher, rankings/map tabs, etc.) */
-
-.filter {
-    margin-bottom: 1rem;
-}
-
-.filter .nav-link i,
-.filter .nav-link svg {
-    margin-right: 0.5rem;
-}
-
-.nav-tabs.filter {
-    border-bottom: var(--bs-border-width) solid var(--bs-border-color);
-}
-
-.nav-tabs.filter .nav-link {
-    border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
-    border: 1px solid var(--bs-border-color);
-    border-bottom: 0;
-    background-color: var(--bs-body-bg);
-    color: var(--bs-body-color);
-    padding-top: 0.25rem;
-    padding-bottom: 0.25rem;
-    margin-bottom: 0;
-    transition: background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
-}
-
-.nav-tabs.filter .nav-link:not(.active):hover {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-    box-shadow: var(--bs-shadow);
-}
-
-.nav-tabs.filter .nav-link:not(.active):hover i,
-.nav-tabs.filter .nav-link:not(.active):hover svg,
-.nav-tabs.filter .nav-link:not(.active):hover [class*="fa-"] {
-    color: var(--bs-primary-text) !important;
-}
-
-.nav-tabs.filter .nav-link.active,
-.nav-tabs.filter .nav-link.active:focus {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-}
-
-.nav-tabs.filter .nav-link.active i,
-.nav-tabs.filter .nav-link.active svg,
-.nav-tabs.filter .nav-link.active:hover i,
-.nav-tabs.filter .nav-link.active:hover svg {
-    color: var(--bs-primary-text) !important;
-}
-
-.nav-tabs.filter .nav-link.active:hover {
-    filter: brightness(1.3);
-}
-
-/* Top nav tabs */
-
-.nav-tabs.topnav {
-    border-bottom: 0;
-}
-
-.nav-tabs.topnav .nav-link {
-    border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
-    border: 1px solid var(--bs-border-color);
-    border-bottom: 0;
-    padding-top: 0.15rem;
-    padding-bottom: 0.15rem;
-    margin-bottom: 0;
-    color: var(--bs-body-color);
-    transition: background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease;
-}
-
-.nav-tabs.topnav .nav-link:not(.active):hover {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-}
-
-.nav-tabs.topnav .nav-link.active,
-.nav-tabs.topnav .nav-link.active:focus {
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-}
-
-.nav-tabs.topnav .nav-link.active i,
-.nav-tabs.topnav .nav-link.active svg {
-    color: var(--bs-primary-text) !important;
-}
-
-.nav-tabs.topnav .nav-link.active:hover {
-    filter: brightness(1.3);
-}
-
-/* Per-icon colors (dark mode default) */
-.nav-tabs.topnav .nav-link:not(.active) .fa-bars-progress {
-    color: var(--bs-primary) !important;
-}
-
-.nav-tabs.topnav .nav-link:not(.active) .fa-certificate {
-    color: #ffbe2e !important;
-}
-
-.nav-tabs.topnav .nav-link:not(.active) .fa-diagram-project {
-    color: #7efbe1 !important;
-}
-
-.nav-tabs.topnav .nav-link:not(.active) .fa-file-lines {
-    color: #a8f2ff !important;
-}
-
-.nav-tabs.topnav .nav-link:not(.active) .fa-database {
-    color: #a8f5d5 !important;
-}
-
-/* Per-icon colors (light mode) */
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-bars-progress {
-    color: #8a4f00 !important;
-}
-
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-certificate {
-    color: #8a6500 !important;
-}
-
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-diagram-project {
-    color: #0d7a6e !important;
-}
-
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-file-lines {
-    color: #1a6fa0 !important;
-}
-
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-database {
-    color: #0d6b52 !important;
-}
-
-/* Hover overrides for per-icon colors — must come after default icon rules, with :hover for higher specificity */
-.nav-tabs.topnav .nav-link:not(.active):hover .fa-bars-progress,
-.nav-tabs.topnav .nav-link:not(.active):hover .fa-certificate,
-.nav-tabs.topnav .nav-link:not(.active):hover .fa-diagram-project,
-.nav-tabs.topnav .nav-link:not(.active):hover .fa-file-lines,
-.nav-tabs.topnav .nav-link:not(.active):hover .fa-database {
-    color: var(--bs-primary-text) !important;
-}
-
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-bars-progress,
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-certificate,
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-diagram-project,
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-file-lines,
-[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-database {
-    color: var(--bs-primary-text) !important;
-}
-
-/* Pagination */
-
-.page-link {
-    color: inherit;
-    background-color: transparent;
-    border-color: var(--bs-border-color);
-}
-
-.page-link:hover {
-    color: var(--bs-primary-text);
-    background-color: var(--bs-primary);
-    border-color: var(--bs-primary);
-}
-
-.active>.page-link,
-.page-link.active {
-    background-color: var(--bs-primary);
-    border-color: var(--bs-primary);
-    color: var(--bs-primary-text);
-}
-
-.page-item.disabled .page-link {
-    color: var(--bs-secondary-color);
-    background-color: transparent;
-    border-color: var(--bs-border-color);
-}
-
-[data-bs-theme=light] .page-link {
-    color: inherit;
-}
-
-[data-bs-theme=light] .page-link:hover,
-[data-bs-theme=light] .active>.page-link,
-[data-bs-theme=light] .page-link.active {
-    color: var(--bs-primary-text);
-}
-
-/* Sortable tables */
-th.sortable {
-    cursor: pointer;
-    user-select: none;
-    white-space: nowrap;
-}
-
-/* Default table styling: border, hover, and shadow without per-table modifier
-   classes. Excludes dense .table-sm data tables, which stay minimal. */
-.table:not(.table-sm) > :not(caption) > * {
-    border-width: var(--bs-border-width) 0;
-}
-
-.table:not(.table-sm) > :not(caption) > * > * {
-    border-width: 0 var(--bs-border-width);
-}
-
-.table:not(.table-sm) > tbody > tr:hover > * {
-    --bs-table-color-state: var(--bs-table-hover-color);
-    --bs-table-bg-state: var(--bs-table-hover-bg);
-}
-
-.table:not(.table-sm) {
-    box-shadow: var(--bs-box-shadow);
-    font-size: 0.95rem;
-}
-
-/* Rankings table */
-
-.rankings-col-site {
-    word-break: break-word;
-}
-
-/* Dropdown */
-
-.dropdown-toggle::after {
-    display: none;
-}
-
-.dropdown-toggle svg {
-    color: var(--bs-btn-color) !important;
-    transition: 0.15s color;
-}
-
-.dropdown-toggle:hover svg,
-.dropdown-toggle:focus svg {
-    color: var(--bs-btn-hover-color) !important;
-}
-
-/* Code blocks */
-
-.highlighter-rouge {
-    margin-bottom: 1rem;
-}
-
-code.language-plaintext {
-    background-color: var(--bs-tertiary-bg);
-    border-radius: 0.2rem;
-    font-family: var(--bs-font-monospace);
-    font-size: 0.875em;
-    padding: 0.1em 0.35em;
-}
-
-/* Page actions (Rescan / Download / Share) */
-
-.actions>li>a,
-.actions>li>button {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.65rem 0.9rem;
-    color: var(--bs-body-color);
-    text-decoration: none;
-    background: none;
-    border: none;
-    cursor: pointer;
-}
-
-.actions>li>a small,
-.actions>li>button small {
-    border-left: 1px solid var(--bs-border-color);
-    padding-left: 0.5rem;
-    align-self: stretch;
-    display: inline-flex;
-    align-items: center;
-}
-
-.actions>li>a:hover,
-.actions>li>a:focus,
-.actions>li>button:hover,
-.actions>li>button:focus {
-    color: var(--bs-link-color);
-}
-
-.actions .list-group-item:hover {
-    background-color: var(--bs-body-secondary-bg);
-}
-
-.actions .dropdown-item {
-    border-bottom: 1px solid var(--bs-border-color);
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-}
-
-.actions .dropdown-menu li:last-child .dropdown-item {
-    border-bottom: none;
-}
-
-.actions .dropdown-item:hover,
-.actions .dropdown-item:focus {
-    background-color: transparent;
-    color: var(--bs-link-color);
-}
-
-.input-group>.btn:not(:first-child) {
-    border-top-right-radius: var(--bs-border-radius-lg) !important;
-    border-bottom-right-radius: var(--bs-border-radius-lg) !important;
-}
-
-.dropdown-menu.show {
-    display: block;
-}
-
-/* Badge */
-
-.badge {
-    font-family: "Public Sans Regular", sans-serif !important;
-    padding: .55rem !important;
-    font-size: .8rem !important;
-    font-weight: 300;
-    border-radius: var(--bs-border-radius-sm) !important;
-}
-
-.badge-primary:hover {
-    background-color: #fee685 !important;
-    /* WCAG 2.2 AA: #13171f on #fee685 = 14.42:1 ✓ */
-    color: #13171f !important;
-}
-
-/* Page sections */
-
-.page-section {
-    padding-bottom: 3rem;
-    margin-bottom: 3rem;
-    border-bottom: 1px solid var(--bs-border-color);
-}
-
-.page-section:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
-    margin-bottom: 0;
-}
-
-/* CTA */
-
-.cta {
-    margin-top: 3rem;
-}
-
-.cta .alert {
-    padding-top: 3rem;
-    padding-bottom: 3rem;
-}
-
-.cta .alert h2 {
-    margin-top: 0.5rem;
-    margin-bottom: 1.5rem;
-}
-
-.cta .alert p {
-    margin-bottom: 1.5rem;
-}
-
-/* Cards */
-
-.card {
-    border: 1px solid var(--bs-border-color);
-    box-shadow: var(--bs-shadow);
-    width: 100%;
-    transition: filter 0.25s ease, box-shadow 0.25s ease;
-}
-
-
-.card:focus,
-.card:focus-within {
-    box-shadow: var(--bs-card-focus-box-shadow);
-}
-
-a.card {
-    text-decoration: none;
-}
-
-.card:not(.text-bg-success):not(.text-bg-warning):not(.text-bg-danger):hover {
-    filter: brightness(1.3);
-    box-shadow: var(--bs-box-shadow-md);
-}
-
-[data-bs-theme=light] .card:not(.text-bg-success):not(.text-bg-warning):not(.text-bg-danger):hover {
-    filter: brightness(0.97);
-}
-
-.card-body i+h3 {
-    margin-top: 0.75rem;
-    margin-bottom: 0.5rem;
-}
-
-.card:has(.stretched-link) {
-    border-color: rgba(var(--bs-link-color-rgb), 0.9) !important;
-    opacity: 0.9;
-    transition: border-color 0.2s ease, box-shadow 0.25s ease, opacity 0.2s ease;
-}
-
-.card:has(.stretched-link):hover {
-    border-color: rgba(var(--bs-link-color-rgb), 1) !important;
-    box-shadow: var(--bs-box-shadow-md);
-    opacity: 1;
-    filter: none;
-}
-
-.card-header>a,
-.card-header>a>svg {
-    color: inherit !important;
-}
-
-.card-hover {
-    transition: filter 0.25s ease, box-shadow 0.25s ease;
-}
-
-.card-hover:hover {
-    filter: brightness(1.3);
-    box-shadow: var(--bs-box-shadow-md);
-}
-
-[data-bs-theme=light] .card-hover:hover {
-    filter: brightness(0.97);
-}
-
-/* Status cards — consistent across themes */
-
-.text-bg-success.card {
-    border-color: #70e17b !important;
-}
-
-.text-bg-warning.card {
-    border-color: #face00 !important;
-}
-
-.text-bg-danger.card {
-    border-color: #e41d3d !important;
-}
-
-.text-bg-success.card:hover,
-.text-bg-warning.card:hover,
-.text-bg-danger.card:hover {
-    filter: brightness(1.3);
-    box-shadow: var(--bs-box-shadow-md);
-}
-
-/* Icons and links inside status cards match card text color */
-.card.text-bg-success i, .card.text-bg-success svg,
-.card.text-bg-success a, .card.text-bg-success a:visited, .card.text-bg-success a:hover,
-.card.text-bg-warning i, .card.text-bg-warning svg,
-.card.text-bg-warning a, .card.text-bg-warning a:visited, .card.text-bg-warning a:hover {
-    color: #13171f !important;
-    fill: #13171f !important;
-}
-
-.card.text-bg-danger i, .card.text-bg-danger svg,
-.card.text-bg-danger a, .card.text-bg-danger a:visited, .card.text-bg-danger a:hover {
-    color: #ffffff !important;
-    fill: #ffffff !important;
-}
-
-.text-bg-success .card-header,
-.text-bg-warning .card-header,
-.text-bg-danger .card-header {
-    background-color: rgba(255, 255, 255, 0.15) !important;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.2) !important;
-    padding: 0.75rem 1rem;
-    font-family: var(--bs-font-regular);
-    --bs-card-cap-bg: rgba(255, 255, 255, 0.15);
-}
-
-.text-bg-success .card-body,
-.text-bg-warning .card-body,
-.text-bg-danger .card-body {
-    padding: 1rem;
-}
-
-/* Grade cards */
-
-.card-grade,
-.card-grade-sm {
-    margin-bottom: 0;
-}
-
-.card-grade .card-body {
-    text-align: center;
-    padding-top: 2.5rem;
-    padding-bottom: 2.5rem;
-}
-
-.card-grade-sm .card-body {
-    text-align: center;
-    padding-top: 1.25rem;
-    padding-bottom: 1.25rem;
-}
-
-.card-grade-sm .card-body .display-2 {
-    margin-bottom: 0;
-}
-
-/* Forms */
-
-form button[type="submit"],
-form input[type="submit"] {
-    margin-bottom: 2rem;
-}
-
-td form button[type="submit"],
-td form input[type="submit"] {
-    margin-bottom: 0;
-}
-
-.form-group {
-    margin-bottom: 1rem;
-}
-
-.form-label .fa-asterisk {
-    margin-left: 0.25rem;
-}
-
-.form-error {
-    color: var(--bs-danger);
-    font-size: 0.875rem;
-    margin-top: 0.25rem;
-    display: none;
-}
-
-.form-control {
-    color: var(--bs-body-color) !important;
-    border: 1px solid var(--bs-border-color);
-    box-shadow: var(--bs-shadow);
-    transition: filter 0.25s ease, box-shadow 0.25s ease;
-}
-
-.form-control:hover {
-    filter: brightness(1.05);
-    box-shadow: var(--bs-box-shadow-md);
-}
-
-.form-control:focus {
-    border-color: var(--bs-primary);
-    box-shadow: var(--bs-form-control-focus-box-shadow);
-    filter: none;
-}
-
-::placeholder, ::-ms-input-placeholder {
-    color: var(--bs-body-color);
-    opacity: var(--bs-text-opacity);
-}
-
-input[type="submit"] {
-    min-width: 80px;
-}
-
-.progress {
-    height: 6px;
-}
-
-/* SVG */
-
-svg {
-    display: inline-block;
-    height: 1em;
-    overflow: visible;
-    vertical-align: -.125em;
-    margin: 0 .3rem;
-    flex-shrink: 0;
-    width: 1em;
-}
-
-svg.sizeicon-xl {
-    height: 1.5em;
-    max-width: 1.5em;
-    line-height: .04167em;
-}
-
-table td svg {
-    margin: 0;
-}
-
-/* FA size classes override the default 1em height */
-.fa-2xs svg {
-    height: 0.625em;
-}
-
-.fa-xs svg {
-    height: 0.75em;
-}
-
-.fa-sm svg {
-    height: 0.875em;
-}
-
-.fa-lg svg {
-    height: 1.25em;
-}
-
-.fa-xl svg {
-    height: 1.5em;
-}
-
-.fa-2xl svg {
-    height: 2em;
-}
-
-.fa-2x svg {
-    height: 2em;
-}
-
-.fa-3x svg {
-    height: 3em;
-}
-
-.fa-4x svg {
-    height: 4em;
-}
-
-.fa-5x svg {
-    height: 5em;
-}
-
-.fa-6x svg {
-    height: 6em;
-}
-
-.fa-7x svg {
-    height: 7em;
-}
-
-.fa-8x svg {
-    height: 8em;
-}
-
-.fa-9x svg {
-    height: 9em;
-}
-
-.fa-10x svg {
-    height: 10em;
-}
-
-svg.fa-circle-check {
-    fill: var(--bs-success);
-}
-
-svg.fa-circle-xmark {
-    fill: var(--bs-danger);
-}
-
-svg.fa-circle-exclamation {
-    fill: var(--bs-warning);
-}
-
-svg.fa-circle-right {
-    fill: var(--bs-info);
-}
-
-svg.fa-arrow-right-arrow-left {
-    fill: var(--bs-warning);
-}
-
-/* Images */
-
-main#home img {
-    display: block;
-    margin: auto;
-    margin-bottom: 0.5rem;
-}
-
-/* Accessibility utilities */
-
-.fa-sr-only, .fa-sr-only-focusable:not(:focus), .sr-only, .sr-only-focusable:not(:focus) {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
-}
-
-.d-none {
-    display: none;
-}
-
-
-/* Timeline */
-
-.timeline {
-    border-left: 1px solid hsl(0, 0%, 90%);
-    position: relative;
-    list-style: none;
-}
-
-.timeline .timeline-item {
-    position: relative;
-}
-
-.timeline .timeline-item:after {
-    position: absolute;
-    display: block;
-    top: 0;
-    background-color: hsl(0, 0%, 90%);
-    left: -38px;
-    border-radius: 50%;
-    height: 11px;
-    width: 11px;
-    content: '';
-}
-
-.timeline-domain {
-    margin-bottom: 0.25rem;
-}
-
-.timeline-date {
-    font-family: var(--bs-font-bold);
-}
-
-/* Anchor links */
-
-a.heading-anchor-text {
-    color: inherit !important;
-    text-decoration: none;
-}
-
-h2 a#heading-hashtag,
-h3 a#heading-hashtag {
-    display: none;
-    color: var(--bs-link-color);
-    text-decoration: none;
-    margin-left: 0.4rem;
-    font-size: 0.75em;
-    vertical-align: middle;
-}
-
-h2 a#heading-hashtag svg,
-h3 a#heading-hashtag svg {
-    color: var(--bs-link-color) !important;
-    fill: var(--bs-link-color) !important;
-}
-
-h2:hover a#heading-hashtag,
-h3:hover a#heading-hashtag {
-    display: inline;
-}
-
-/* iframe */
-
-iframe {
-    border: 1px solid var(--bs-border-color) !important;
-}
-
-/* News posts */
-
-.post-content h2 {
-    margin-top: 2.75rem;
-}
-
-.post-content ul, .post-content p {
-    margin-bottom: 1.75rem;
-}
-
-/* Autocomplete search */
-
-.awesomplete [hidden] {
-    display: none;
-}
-
-.awesomplete .visually-hidden {
-    position: absolute;
-    clip: rect(0, 0, 0, 0);
-}
-
-.awesomplete {
-    display: block;
-    position: relative;
-}
-
-.awesomplete>input {
-    display: block;
-}
-
-.awesomplete>ul {
-    position: absolute;
-    left: 0;
-    z-index: 1;
-    min-width: 100%;
-    box-sizing: border-box;
-    list-style: none;
-    padding: 0;
-    margin: 0.2em 0 0;
-    color: var(--bs-body-color);
-    background-color: var(--bs-body-bg);
-    border: var(--bs-border-width) solid var(--bs-border-color);
-    border-radius: var(--bs-border-radius);
-    box-shadow: 0.05em 0.2em 0.6em rgba(0, 0, 0, 0.2);
-    text-shadow: none;
-}
-
-.awesomplete>ul:empty {
-    display: none;
-}
-
-@supports (transform: scale(0)) {
-    .awesomplete>ul {
-        transition: 0.3s cubic-bezier(0.4, 0.2, 0.5, 1.4);
-    }
-
-    .awesomplete>ul[hidden],
-    .awesomplete>ul:empty {
-        opacity: 0;
-        transform: scale(0);
-        display: block;
-        visibility: hidden;
-        transition-timing-function: ease;
-    }
-}
-
-.awesomplete>ul>li {
-    position: relative;
-    padding: 0.7em 1em;
-    cursor: pointer;
-}
-
-.awesomplete>ul>li:hover {
-    background: hsl(200, 40%, 80%);
-    color: black;
-}
-
-.awesomplete>ul>li[aria-selected='true'] {
-    background: hsl(205, 40%, 40%);
-    color: white;
-}
-
-.awesomplete mark {
-    background: hsl(65, 100%, 50%);
-}
-
-.awesomplete li:hover mark {
-    background: hsl(68, 100%, 41%);
-}
-
-.awesomplete li[aria-selected='true'] mark {
-    background: hsl(86, 100%, 21%);
-    color: inherit;
-}
-
-/* File types */
-
-a[href$=".doc"]::after,
-a[href$=".docx"]::after,
-a[href$=".ppt"]::after,
-a[href$=".pptx"]::after,
-a[href$=".xls"]::after,
-a[href$=".xlsx"]::after,
-a[href$=".pdf"]::after,
-a[href$=".mp3"]::after,
-a[href$=".mp4"]::after,
-a[href$=".avi"]::after,
-a[href$=".mpg"]::after,
-a[href$=".mpeg"]::after,
-a[href$=".mov"]::after,
-a[href$=".wmv"]::after,
-a[href$=".mkv"]::after,
-a[href$=".jpg"]::after,
-a[href$=".jpeg"]::after,
-a[href$=".png"]::after,
-a[href$=".gif"]::after {
-    content: "";
-    display: inline-block;
-    width: 1em;
-    height: 1em;
-    margin-left: 0.5rem;
-    background-size: contain;
-    background-repeat: no-repeat;
-}
-
-a[href$=".doc"]::after,
-a[href$=".docx"]::after {
-    background-image: url(/assets/font-awesome/svgs/solid/file-word.svg);
-}
-
-a[href$=".ppt"]::after,
-a[href$=".pptx"]::after {
-    background-image: url(/assets/font-awesome/svgs/solid/file-powerpoint.svg);
-}
-
-a[href$=".xls"]::after,
-a[href$=".xlsx"]::after {
-    background-image: url(/assets/font-awesome/svgs/solid/file-excel.svg);
-}
-
-a[href$=".pdf"]::after {
-    background-image: url(/assets/font-awesome/svgs/solid/file-pdf.svg);
-}
-
-a[href$=".mp3"]::after {
-    background-image: url(/assets/font-awesome/svgs/solid/file-audio.svg);
-}
-
-a[href$=".mp4"]::after {
-    background-image: url(/assets/font-awesome/svgs/solid/file-video.svg);
-}
-
-.fa-bluesky {
-    color: #96abee !important;
-}
-
-.fa-mastodon {
-    color: #d5bfff !important;
-}
-
-.fa-book-open {
-    color: #c3ebfa !important;
-}
-
-.fa-book-open-reader {
-    color: #c3ebfa !important;
-}
-
-.fa-check {
-    color: #e7f434 !important;
-}
-
-.fa-circle-exclamation {
-    color: #ffbc78 !important;
-}
-
-.fa-circle-plus,
-.fa-toggle-on {
-    color: var(--bs-success) !important;
-}
-
-.fa-user-plus {
-    color: var(--bs-success) !important;
-}
-
-.fa-circle-dot {
-    color: #f3bf90 !important;
-}
-
-.fa-circle-down {
-    color: #e41d3d !important;
-}
-
-.fa-circle-up {
-    color: #21c834 !important;
-}
-
-.fa-comments {
-    color: #c5c5f3 !important;
-}
-
-.fa-dolly {
-    color: #f5fbc1 !important;
-}
-
-.fa-download {
-    color: #c3ebfa;
-}
-
-.fa-file-contract {
-    color: #fee685 !important;
-}
-
-.fa-file-pdf {
-    color: #f8b9c5 !important;
-}
-
-.fa-filter-circle-xmark {
-    color: #f8b9c5 !important;
-}
-
-.fa-box-archive {
-    color: #f8b9c5 !important;
-}
-
-.fa-fire {
-    color: #ffbc78 !important;
-}
-
-.fa-screwdriver-wrench {
-    color: #ffbc78;
-}
-
-.fa-highlighter {
-    color: #e7f434 !important;
-}
-
-.fa-plug-circle-bolt {
-    color: #fff5c2 !important;
-}
-
-.fa-puzzle-piece {
-    color: #98d035 !important;
-}
-
-.fa-rotate {
-    color: #c5ee93 !important;
-}
-
-.fa-share-from-square {
-    color: #f8b9c5 !important;
-}
-
-/* Icons — dark mode (vibrant pastels on dark bg) */
-
-.fa-github {
-    color: #96abee !important;
-}
-
-.fa-discord {
-    color: #96abee !important;
-}
-
-.fa-linkedin,
-.fa-linkedin-in {
-    color: #c3ebfa !important;
-}
-
-.fa-x-twitter {
-    color: #e4e4e4 !important;
-}
-
-.fa-youtube {
-    color: #fd8ba0 !important;
-}
-
-.fa-arrows-rotate {
-    color: #c5ee93 !important;
-}
-
-.fa-compact-disc {
-    color: #c5ee93 !important;
-}
-
-.fa-arrow-right-to-bracket {
-    color: var(--bs-success) !important;
-}
-
-.fa-arrow-right-arrow-left {
-    color: #face00 !important;
-}
-
-.fa-arrow-pointer {
-    color: #d5bfff;
-}
-
-.fa-asterisk {
-    color: #face00;
-}
-
-.fa-bars-progress {
-    color: #ffbc78;
-}
-
-.fa-bell {
-    color: #29e1cb !important;
-}
-
-.fa-bell-concierge {
-    color: #dec69a !important;
-}
-
-.fa-life-ring {
-    color: #dec69a !important;
-}
-
-.fa-bolt {
-    color: #face00 !important;
-}
-
-.fa-brain {
-    color: #fdb8ae !important;
-}
-
-.fa-broom {
-    color: #face00 !important;
-}
-
-.fa-bug {
-    color: #fbbaa7;
-}
-
-.fa-building {
-    color: #b7f5bd !important;
-}
-
-.fa-binoculars {
-    color: #7de8d0 !important;
-}
-
-.fa-bullhorn {
-    color: #96abee !important;
-}
-
-.fa-calendar {
-    color: #a8f2ff !important;
-}
-
-.fa-certificate {
-    color: #ffbe2e !important;
-}
-
-.fa-check-to-slot {
-    color: #ffb4cf !important;
-}
-
-.fa-circle-check {
-    color: var(--bs-success) !important;
-}
-
-.fa-circle-xmark {
-    color: #e41d3d !important;
-}
-
-.fa-circle-nodes {
-    color: #c3ebfa;
-}
-
-.fa-circle-notch {
-    color: #e6e6e6 !important;
-}
-
-.fa-circle-question {
-    color: #97d4ea;
-}
-
-a .fa-circle-question,
-a:hover .fa-circle-question,
-a .fa-circle-info,
-a:hover .fa-circle-info {
-    color: inherit !important;
-}
-
-td a .fa-circle-question,
-td a:hover .fa-circle-question,
-td a .fa-circle-info,
-td a:hover .fa-circle-info {
-    color: var(--bs-body-color) !important;
-}
-
-.fa-triangle-exclamation {
-    color: #f4a0a0;
-}
-
-.fa-circle-info {
-    color: #b8d293 !important;
-}
-
-.fa-code {
-    color: #bbc8f5 !important;
-}
-
-.fa-comment {
-    color: #c5c5f3 !important;
-}
-
-.fa-crown {
-    color: #ffe396 !important;
-}
-
-.fa-dashboard {
-    color: #ffbc78;
-}
-
-.fa-diagram-project {
-    color: #7efbe1 !important;
-}
-
-.fa-envelope {
-    color: #c3ebfa;
-}
-
-.fa-envelope-open-text {
-    color: #7efbe1 !important;
-}
-
-.fa-eye {
-    color: #7de8d0;
-}
-
-.fa-face-sad-tear {
-    color: #face00;
-}
-
-.fa-dove,
-.fa-face-grin-hearts,
-.fa-face-smile {
-    color: #fffb00;
-}
-
-.fa-file {
-    color: #a8f2ff;
-}
-
-.fa-file-lines {
-    color: #a8f2ff;
-}
-
-.fa-filter {
-    color: #cbc4f2;
-}
-
-.fa-flag {
-    color: #f45d79;
-}
-
-.fa-gauge {
-    color: #ffbc78;
-}
-
-.fa-gauge-simple {
-    color: #ffbc78;
-}
-
-.fa-gauge-high {
-    color: #ffbc78;
-}
-
-.fa-chart-line {
-    color: #ffbc78;
-}
-
-.fa-gear,
-.fa-gears {
-    color: #a1d3ff;
-}
-
-.fa-network-wired {
-    color: #a1d3ff;
-}
-
-.fa-graduation-cap {
-    color: #c7efe2;
-}
-
-.fa-hand, .fa-hands, .fa-hands-clapping,
-.fa-handshake,
-.fa-handshake-simple, .fa-handshake-angle,
-.fa-hand-peace,
-.fa-hand-point-up, .fa-hand-point-down,
-.fa-hand-point-right, .fa-hand-point-left {
-    color: #face00;
-}
-
-.fa-hand-pointer {
-    color: #d5bfff;
-}
-
-.fa-heart {
-    color: #ff8d7b;
-}
-
-.fa-heart-crack {
-    color: #ff8d7b;
-}
-
-.fa-house {
-    color: #f4b2ff;
-}
-
-.fa-key {
-    color: #fee685;
-}
-
-.fa-laptop {
-    color: #9bd4cf;
-}
-
-.fa-landmark {
-    color: #b0d0f0 !important;
-}
-
-.fa-lightbulb,
-.fa-message {
-    color: #ffe396 !important;
-}
-
-.fa-link {
-    color: #7efbe1;
-}
-
-.fa-list-check {
-    color: #c3ebfa;
-}
-
-.fa-lock {
-    color: #ff8d7b;
-}
-
-.fa-magnifying-glass,
-.fa-magnifying-glass-chart {
-    color: #ffe396;
-}
-
-.fa-map {
-    color: #fdb8ae;
-}
-
-.fa-newspaper {
-    color: #b0d0f0;
-}
-
-.fa-paper-plane {
-    color: #c3ebfa;
-}
-
-.fa-percent {
-    color: #a8f2ff;
-}
-
-.fa-ranking-star {
-    color: #83fcd4;
-}
-
-.fa-rectangle-list {
-    color: #f8b9c5;
-}
-
-.fa-folder-tree,
-.fa-sitemap {
-    color: #ffbc78 !important;
-}
-
-.fa-right-from-bracket {
-    color: var(--bs-success) !important;
-}
-
-.fa-robot {
-    color: #e7f434 !important;
-}
-
-.fa-rocket {
-    color: #d0c3e9;
-}
-
-.fa-rss {
-    color: #ffbc78;
-}
-
-.fa-satellite-dish {
-    color: #c3ebfa !important;
-}
-
-.fa-scale-balanced {
-    color: #e6c74c;
-}
-
-.fa-scroll {
-    color: #fee685 !important;
-}
-
-.fa-seedling {
-    color: #c5ee93;
-}
-
-.fa-server {
-    color: #fbbaa7;
-}
-
-.fa-share-nodes {
-    color: #ffb4cf;
-}
-
-.fa-shield-halved {
-    color: #ff8d7b;
-}
-
-.fa-spray-can-sparkles {
-    color: #d0b4f5;
-}
-
-.fa-square-check {
-    color: #c3ebfa;
-}
-
-.fa-star {
-    color: #e6c74c;
-}
-
-.fa-table {
-    color: #7efbe1;
-}
-
-.fa-table-columns {
-    color: #7efbe1;
-}
-
-.fa-database {
-    color: #a8f5d5;
-}
-
-.fa-timeline {
-    color: #ffb4cf;
-}
-
-.fa-universal-access {
-    color: #a8f2ff;
-}
-
-.fa-arrow-right,
-.fa-arrow-right-long {
-    color: #c3ebfa;
-}
-
-.fa-copy {
-    color: #7efbe1;
-}
-
-.fa-face-frown {
-    color: #fbbaa7;
-}
-
-.fa-print {
-    color: #d0c3e9;
-}
-
-.fa-up-right-from-square {
-    color: #7efbe1;
-}
-
-a .fa-up-right-from-square {
-    margin-left: 0.3em;
-}
-
-.fa-user-astronaut {
-    color: #f8b9c5;
-}
-
-.fa-user-group {
-    color: #96abee;
-}
-
-.fa-user-shield {
-    color: #f3bf90;
-}
-
-.fa-wand-magic-sparkles {
-    color: #ffe396;
-}
-
-.fa-wave-square {
-    color: #96abee !important;
-}
-
-.fa-window-maximize {
-    color: #ffcdd5;
-}
-
-.fa-building-columns {
-    color: #b0d0f0 !important;
-}
-
-.fa-chart-simple {
-    color: #ffbc78 !important;
-}
-
-.fa-check-circle {
-    color: var(--bs-success) !important;
-}
-
-.fa-circle-play {
-    color: #7de8d0 !important;
-}
-
-.fa-concierge-bell {
-    color: #dec69a !important;
-}
-
-.fa-photo-film {
-    color: #d5bfff !important;
-}
-
-.fa-stop-circle {
-    color: #ffbc78 !important;
-}
-
-/* Icons — light mode overrides (WCAG 2.2 AA compliant, min 4.5:1 on #fff) */
-
-[data-bs-theme=light] .fa-arrow-right-to-bracket,
-[data-bs-theme=light] .fa-arrows-rotate,
-[data-bs-theme=light] .fa-compact-disc,
-[data-bs-theme=light] .fa-building,
-[data-bs-theme=light] .fa-check-circle,
-[data-bs-theme=light] .fa-circle-check,
-[data-bs-theme=light] .fa-circle-info,
-[data-bs-theme=light] .fa-circle-plus,
-[data-bs-theme=light] .fa-puzzle-piece,
-[data-bs-theme=light] .fa-right-from-bracket,
-[data-bs-theme=light] .fa-rotate,
-[data-bs-theme=light] .fa-seedling,
-[data-bs-theme=light] .fa-toggle-on {
-    /* → #2d7a3a = 5.31:1 ✓ */
-    color: #2d7a3a !important;
-}
-
-[data-bs-theme=light] .fa-bell,
-[data-bs-theme=light] .fa-copy,
-[data-bs-theme=light] .fa-diagram-project,
-[data-bs-theme=light] .fa-envelope-open-text,
-[data-bs-theme=light] .fa-graduation-cap,
-[data-bs-theme=light] .fa-link,
-[data-bs-theme=light] .fa-ranking-star,
-[data-bs-theme=light] .fa-table,
-[data-bs-theme=light] .fa-table-columns,
-[data-bs-theme=light] .fa-up-right-from-square {
-    /* → #0d7a6e = 5.22:1 ✓ */
-    color: #0d7a6e !important;
-}
-
-[data-bs-theme=light] .fa-bell-concierge,
-[data-bs-theme=light] .fa-brain,
-[data-bs-theme=light] .fa-bug,
-[data-bs-theme=light] .fa-concierge-bell,
-[data-bs-theme=light] .fa-face-frown,
-[data-bs-theme=light] .fa-life-ring,
-[data-bs-theme=light] .fa-map,
-[data-bs-theme=light] .fa-server {
-    /* → #8a5e2d = 5.65:1 ✓ */
-    color: #8a5e2d !important;
-}
-
-[data-bs-theme=light] .fa-bolt,
-[data-bs-theme=light] .fa-broom,
-[data-bs-theme=light] .fa-certificate,
-[data-bs-theme=light] .fa-check,
-[data-bs-theme=light] .fa-crown,
-[data-bs-theme=light] .fa-dolly,
-[data-bs-theme=light] .fa-dove,
-[data-bs-theme=light] .fa-face-grin-hearts,
-[data-bs-theme=light] .fa-face-sad-tear,
-[data-bs-theme=light] .fa-face-smile,
-[data-bs-theme=light] .fa-file-contract,
-[data-bs-theme=light] .fa-hand, [data-bs-theme=light] .fa-hands,
-[data-bs-theme=light] .fa-key,
-[data-bs-theme=light] .fa-hands-clapping,
-[data-bs-theme=light] .fa-handshake,
-[data-bs-theme=light] .fa-handshake-simple,
-[data-bs-theme=light] .fa-handshake-angle,
-[data-bs-theme=light] .fa-hand-peace,
-[data-bs-theme=light] .fa-hand-point-up,
-[data-bs-theme=light] .fa-hand-point-down,
-[data-bs-theme=light] .fa-hand-point-right,
-[data-bs-theme=light] .fa-hand-point-left,
-[data-bs-theme=light] .fa-highlighter,
-[data-bs-theme=light] .fa-lightbulb,
-[data-bs-theme=light] .fa-message,
-[data-bs-theme=light] .fa-magnifying-glass,
-[data-bs-theme=light] .fa-magnifying-glass-chart,
-[data-bs-theme=light] .fa-plug-circle-bolt,
-[data-bs-theme=light] .fa-robot,
-[data-bs-theme=light] .fa-scale-balanced,
-[data-bs-theme=light] .fa-scroll,
-[data-bs-theme=light] .fa-star,
-[data-bs-theme=light] .fa-stop-circle,
-[data-bs-theme=light] .fa-wand-magic-sparkles {
-    /* → #8a6500 = 5.33:1 ✓ */
-    color: #8a6500 !important;
-}
-
-[data-bs-theme=light] .fa-arrow-right-arrow-left,
-[data-bs-theme=light] .fa-asterisk {
-    /* → #8a6500 on #fff = 5.33:1 ✓ */
-    color: #8a6500 !important;
-}
-
-[data-bs-theme=light] .fa-bars-progress,
-[data-bs-theme=light] .fa-chart-simple,
-[data-bs-theme=light] .fa-chart-line,
-[data-bs-theme=light] .fa-circle-exclamation,
-[data-bs-theme=light] .fa-dashboard,
-[data-bs-theme=light] .fa-fire,
-[data-bs-theme=light] .fa-folder-tree,
-[data-bs-theme=light] .fa-gauge,
-[data-bs-theme=light] .fa-gauge-simple,
-[data-bs-theme=light] .fa-gauge-high,
-[data-bs-theme=light] .fa-rss,
-[data-bs-theme=light] .fa-screwdriver-wrench,
-[data-bs-theme=light] .fa-sitemap {
-    /* → #8a4f00 = 6.56:1 ✓ */
-    color: #8a4f00 !important;
-}
-
-[data-bs-theme=light] .btn.btn-outline-primary .fa-sitemap {
-    color: #8a4f00 !important;
-}
-
-[data-bs-theme=light] .btn.btn-outline-primary:hover .fa-sitemap,
-[data-bs-theme=light] .btn.btn-outline-primary:focus .fa-sitemap {
-    color: inherit !important;
-}
-
-[data-bs-theme=light] .fa-arrow-right,
-[data-bs-theme=light] .fa-arrow-right-long,
-[data-bs-theme=light] .fa-book-open,
-[data-bs-theme=light] .fa-book-open-reader,
-[data-bs-theme=light] .fa-calendar,
-[data-bs-theme=light] .fa-circle-nodes,
-[data-bs-theme=light] .fa-download,
-[data-bs-theme=light] .fa-envelope,
-[data-bs-theme=light] .fa-file,
-[data-bs-theme=light] .fa-file-lines,
-[data-bs-theme=light] .fa-linkedin,
-[data-bs-theme=light] .fa-linkedin-in,
-[data-bs-theme=light] .fa-x-twitter,
-[data-bs-theme=light] .fa-paper-plane,
-[data-bs-theme=light] .fa-percent,
-[data-bs-theme=light] .fa-list-check,
-[data-bs-theme=light] .fa-satellite-dish,
-[data-bs-theme=light] .fa-square-check,
-[data-bs-theme=light] .fa-universal-access {
-    /* → #1a6fa0 = 5.49:1 ✓ */
-    color: #1a6fa0 !important;
-}
-
-[data-bs-theme=light] .fa-binoculars,
-[data-bs-theme=light] .fa-circle-play,
-[data-bs-theme=light] .fa-eye {
-    /* → #1a7a6a = 5.21:1 ✓ */
-    color: #1a7a6a !important;
-}
-
-[data-bs-theme=light] .fa-bluesky,
-[data-bs-theme=light] .fa-code,
-[data-bs-theme=light] .fa-bullhorn,
-[data-bs-theme=light] .fa-discord,
-[data-bs-theme=light] .fa-github,
-[data-bs-theme=light] .fa-user-group,
-[data-bs-theme=light] .fa-wave-square {
-    /* → #4a6bb5 = 5.17:1 ✓ */
-    color: #4a6bb5 !important;
-}
-
-[data-bs-theme=light] .fa-comment,
-[data-bs-theme=light] .fa-comments,
-[data-bs-theme=light] .fa-filter,
-[data-bs-theme=light] .fa-print,
-[data-bs-theme=light] .fa-rocket {
-    /* → #5b4ea0 = 6.90:1 ✓ */
-    color: #5b4ea0 !important;
-}
-
-[data-bs-theme=light] .feedback .fa-rocket {
-    color: inherit !important;
-}
-
-[data-bs-theme=light] .fa-circle-notch {
-    /* → #5a5a5a = 6.90:1 ✓ */
-    color: #5a5a5a !important;
-}
-
-[data-bs-theme=light] .fa-circle-question {
-    /* → #1a6fa0 = 5.49:1 ✓ */
-    color: #1a6fa0;
-}
-
-[data-bs-theme=light] a .fa-circle-question,
-[data-bs-theme=light] a:hover .fa-circle-question,
-[data-bs-theme=light] a .fa-circle-info,
-[data-bs-theme=light] a:hover .fa-circle-info {
-    color: inherit !important;
-}
-
-[data-bs-theme=light] .fa-triangle-exclamation {
-    /* → #b03030 = 5.62:1 ✓ */
-    color: #b03030;
-}
-
-[data-bs-theme=light] .fa-box-archive,
-[data-bs-theme=light] .fa-file-pdf,
-[data-bs-theme=light] .fa-filter-circle-xmark,
-[data-bs-theme=light] .fa-rectangle-list,
-[data-bs-theme=light] .fa-share-from-square,
-[data-bs-theme=light] .fa-user-astronaut {
-    /* → #b5476a = 5.15:1 ✓ */
-    color: #b5476a !important;
-}
-
-[data-bs-theme=light] .fa-circle-down,
-[data-bs-theme=light] .fa-circle-xmark,
-[data-bs-theme=light] .fa-flag {
-    /* → #b52040 = 6.47:1 ✓ */
-    color: #b52040 !important;
-}
-
-[data-bs-theme=light] .fa-circle-up {
-    /* → #1a7a2a = 5.10:1 ✓ */
-    color: #1a7a2a !important;
-}
-
-[data-bs-theme=light] .fa-building-columns,
-[data-bs-theme=light] .fa-circle-dot,
-[data-bs-theme=light] .fa-gear,
-[data-bs-theme=light] .fa-gears,
-[data-bs-theme=light] .fa-network-wired,
-[data-bs-theme=light] .fa-newspaper {
-    /* → #1a5e9e = 6.69:1 ✓ */
-    color: #1a5e9e !important;
-}
-
-[data-bs-theme=light] .fa-heart,
-[data-bs-theme=light] .fa-heart-crack,
-[data-bs-theme=light] .fa-lock,
-[data-bs-theme=light] .fa-shield-halved {
-    /* → #c0392b = 5.44:1 ✓ */
-    color: #c0392b !important;
-}
-
-[data-bs-theme=light] .fa-house {
-    /* → #7a2ea0 = 7.70:1 ✓ */
-    color: #7a2ea0 !important;
-}
-
-[data-bs-theme=light] .fa-laptop {
-    /* → #1a6e6a = 6.03:1 ✓ */
-    color: #1a6e6a !important;
-}
-
-[data-bs-theme=light] .fa-landmark {
-    /* → #1a5e9e = 6.69:1 ✓ */
-    color: #1a5e9e !important;
-}
-
-[data-bs-theme=light] .fa-share-nodes,
-[data-bs-theme=light] .fa-check-to-slot,
-[data-bs-theme=light] .fa-timeline {
-    /* → #9e2060 = 7.42:1 ✓ */
-    color: #9e2060 !important;
-}
-
-[data-bs-theme=light] .fa-database {
-    /* → #0d6b52 = 7.3:1 ✓ */
-    color: #0d6b52 !important;
-}
-
-[data-bs-theme=light] .fa-arrow-pointer,
-[data-bs-theme=light] .fa-hand-pointer,
-[data-bs-theme=light] .fa-mastodon,
-[data-bs-theme=light] .fa-photo-film,
-[data-bs-theme=light] .fa-spray-can-sparkles {
-    /* → #6b3fa0 = 7.38:1 ✓ */
-    color: #6b3fa0 !important;
-}
-
-[data-bs-theme=light] .fa-user-shield {
-    /* → #8a4e00 = 6.62:1 ✓ */
-    color: #8a4e00 !important;
-}
-
-[data-bs-theme=light] .fa-window-maximize {
-    /* → #a03050 = 6.92:1 ✓ */
-    color: #a03050 !important;
-}
-
-[data-bs-theme=light] .fa-youtube {
-    /* → #c0392b = 5.44:1 ✓ */
-    color: #c0392b !important;
-}
-
-/* Status card icons — must come last to beat FA light mode overrides */
-[data-bs-theme=light] .card.text-bg-success,
-[data-bs-theme=light] .card.text-bg-success a,
-[data-bs-theme=light] .card.text-bg-success a:link,
-[data-bs-theme=light] .card.text-bg-success a:visited,
-[data-bs-theme=light] .card.text-bg-success a:hover,
-[data-bs-theme=light] .card.text-bg-success a:focus,
-[data-bs-theme=light] .card.text-bg-success i,
-[data-bs-theme=light] .card.text-bg-success svg,
-[data-bs-theme=light] .card.text-bg-success a i,
-[data-bs-theme=light] .card.text-bg-success a svg,
-[data-bs-theme=light] .card.text-bg-warning,
-[data-bs-theme=light] .card.text-bg-warning a,
-[data-bs-theme=light] .card.text-bg-warning a:link,
-[data-bs-theme=light] .card.text-bg-warning a:visited,
-[data-bs-theme=light] .card.text-bg-warning a:hover,
-[data-bs-theme=light] .card.text-bg-warning a:focus,
-[data-bs-theme=light] .card.text-bg-warning i,
-[data-bs-theme=light] .card.text-bg-warning svg,
-[data-bs-theme=light] .card.text-bg-warning a i,
-[data-bs-theme=light] .card.text-bg-warning a svg {
-    color: #13171f !important;
-    fill: #13171f !important;
-}
-
-[data-bs-theme=light] .card.text-bg-danger,
-[data-bs-theme=light] .card.text-bg-danger a,
-[data-bs-theme=light] .card.text-bg-danger a:link,
-[data-bs-theme=light] .card.text-bg-danger a:visited,
-[data-bs-theme=light] .card.text-bg-danger a:hover,
-[data-bs-theme=light] .card.text-bg-danger a:focus,
-[data-bs-theme=light] .card.text-bg-danger i,
-[data-bs-theme=light] .card.text-bg-danger svg,
-[data-bs-theme=light] .card.text-bg-danger a i,
-[data-bs-theme=light] .card.text-bg-danger a svg {
-    color: #ffffff !important;
-    fill: #ffffff !important;
-}
-
-/* text-bg-dark card icons match white text */
-.card.text-bg-dark a,
-.card.text-bg-dark a:link,
-.card.text-bg-dark a:visited,
-.card.text-bg-dark a:hover,
-.card.text-bg-dark a:focus,
-.card.text-bg-dark i,
-.card.text-bg-dark svg,
-.card.text-bg-dark a i,
-.card.text-bg-dark a svg {
-    color: #ffffff !important;
-    fill: #ffffff !important;
-}
-
-/* Question mark help icons inherit text color via href targeting */
-a[href*="docs.scangov.org"] svg,
-a[href*="docs.scangov.org"] i {
-    color: inherit !important;
-    fill: currentColor !important;
-}
-
-/* Font Awesome size utilities */
-.fa-2xs {
-    font-size: 0.625em;
-}
-
-.fa-xs {
-    font-size: 0.75em;
-}
-
-.fa-sm {
-    font-size: 0.875em;
-}
-
-.fa-lg {
-    font-size: 1.25em;
-}
-
-.fa-xl {
-    font-size: 1.5em;
-}
-
-.fa-2xl {
-    font-size: 2em;
-}
-
-.fa-1x {
-    font-size: 1em;
-}
-
-.fa-2x {
-    font-size: 2em;
-}
-
-.fa-3x {
-    font-size: 3em;
-}
-
-.fa-4x {
-    font-size: 4em;
-}
-
-.fa-5x {
-    font-size: 5em;
-}
-
-.fa-6x {
-    font-size: 6em;
-}
-
-.fa-7x {
-    font-size: 7em;
-}
-
-.fa-8x {
-    font-size: 8em;
-}
-
-.fa-9x {
-    font-size: 9em;
-}
-
-.fa-10x {
-    font-size: 10em;
-}
-
-select.js-subfilters {
-    width: 100%;
-    border-radius: 0;
-}
-
-select.js-subfilters:hover {
-    --bs-body-bg: var(--bs-primary);
-    background-color: var(--bs-primary) !important;
-    color: var(--bs-primary-text) !important;
-    border-color: var(--bs-primary) !important;
-    box-shadow: var(--bs-shadow) !important;
-    border-radius: 0 !important;
-}
-
-thead th {
-    font-family: var(--bs-font-monospace);
-}
-
-/* Table header links */
-th a {
-    color: var(--bs-link-color);
-    text-decoration: none;
-}
-
-th a:hover {
-    color: var(--bs-link-hover-color);
-    text-decoration: underline;
-}
-
-th a i, th a svg,
-th a:link i, th a:link svg,
-th a:visited i, th a:visited svg,
-th a:hover i, th a:hover svg,
-th a:focus i, th a:focus svg {
-    color: var(--bs-body-color) !important;
-    fill: var(--bs-body-color) !important;
-    text-decoration: none;
-}
-
-/* Docs */
-#post h2 {
-    margin-top: 2.5rem;
-}
-
-#post h3 {
-    margin-top: 2rem;
-    font-size: 1.1rem;
-}
-
-#post .alert h2 {
-    margin-top: 2rem;
-}
-
-#post .alert h3 {
-    margin-top: 2rem;
-    font-size: inherit;
-}
-
-.js-sidenav {
-    top: 1rem;
-}
-
-.js-sidenav a:hover {
-    color: var(--bs-link-color) !important;
-}
-
-.scan-notice {
-    position: fixed;
-    bottom: 1rem;
-    left: 1rem;
-    right: 1rem;
-    z-index: 1050;
-    margin: 0;
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.scan-notice .btn-close {
-    flex-shrink: 0;
-    margin-left: auto;
-}
-
-@media (min-width: 768px) {
-    .scan-notice {
-        width: 75%;
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-    }
-}
-
-/* Actions list: separate boxes — restore left border + full radius on every item */
-.actions.list-group .list-group-item {
-    padding: 0;
-    border-radius: var(--bs-list-group-border-radius) !important;
-}
-
-.actions .list-group-item+.list-group-item {
-    border-left-width: var(--bs-list-group-border-width);
-}
-
-/* Card links: underline on hover only */
-.card a:not(.btn):not(.stretched-link) {
-    text-decoration: none;
-}
-
-.card a:not(.btn):not(.stretched-link):hover {
-    text-decoration: underline;
-}
-
-.card .stretched-link {
-    text-decoration: none;
-}
-
-.card .stretched-link:hover {
-    text-decoration: underline;
-}
-
-/* Card heading links: body color by default, link color on hover */
-.card h1 a, .card h2 a, .card h3 a,
-.card h4 a, .card h5 a, .card h6 a,
-.card .h1 a, .card .h2 a, .card .h3 a,
-.card .h4 a, .card .h5 a, .card .h6 a {
-    color: var(--bs-body-color);
-    text-decoration: none;
-}
-
-.card h1 a:hover, .card h2 a:hover, .card h3 a:hover,
-.card h4 a:hover, .card h5 a:hover, .card h6 a:hover,
-.card .h1 a:hover, .card .h2 a:hover, .card .h3 a:hover,
-.card .h4 a:hover, .card .h5 a:hover, .card .h6 a:hover {
-    color: var(--bs-link-color);
-    text-decoration: underline;
-}
-
-/* Search no-results icon */
-.fa-signs-post {
-    color: #ffbe2e;
-}
-
-[data-bs-theme=light] .fa-signs-post {
-    color: #8a6500 !important;
-}
-
-/* Lunr search results */
-#lunrsearchresults {
-    padding-top: 0.2rem;
-}
-
-.lunrsearchresult {
-    padding-bottom: 1rem;
-}
-
-.lunrsearchresult .title {
-    color: var(--bs-body-color);
-}
-
-.lunrsearchresult .url {
-    color: var(--bs-body-color);
-}
-
-.lunrsearchresult a {
-    display: block;
-    color: var(--bs-body-color);
-}
-
-.lunrsearchresult a:hover,
-.lunrsearchresult a:focus {
-    text-decoration: none;
-}
-
-.lunrsearchresult a:hover .title {
-    text-decoration: underline;
-}
-
-/* SVG maps */
-svg#report-map,
-svg#map {
-    width: 100%;
-    max-width: 100%;
-    height: auto;
-}
-
-svg#report-map {
-    width: 85%;
-    max-width: 85%;
-}
-
-svg#report-map a,
-svg#map a {
-    transition: 0.5s filter;
-}
-
-svg#report-map a:hover,
-svg#map a:hover {
-    filter: brightness(1.3);
-}
-
-.report-map-borders,
-.borders {
-    stroke: var(--bs-body-bg);
-    stroke-width: 1px;
-}
-
-#report-legend>span,
-#legend>span {
-    margin-left: 1rem;
-}
-
-/* Dataset preview */
-.dataset-preview {
-    max-height: 400px;
-    overflow-y: scroll;
-}
-
-.dataset-preview--code {
-    overflow-x: auto;
-}
-
-/* Timeline icon column min-width */
-.timeline .col-auto {
-    min-width: 4rem;
-}
-
-/* Print */
-.page-break {
-    page-break-before: always;
-}
-
-@media print {
-    body {
-        font-family: "Public Sans Regular", sans-serif;
-    }
-
-    svg {
-        fill: black !important;
-    }
-
-    div.card {
-        border: 1px solid black;
-        background-color: transparent;
-    }
-
-    div.card-header {
-        border-bottom: 1px solid var(--bs-border-color);
-    }
-
-    div.card-footer {
-        border-top: 1px solid var(--bs-border-color);
-    }
-
-    * {
-        color: black !important;
-    }
-
-    main#page {
-        display: none;
-    }
-}
-
-/* Issue report modal */
-.popoverstyling {
-    width: min(700px, 95vw);
-    max-width: 700px;
-    padding: 0;
-    border: none;
-    background: transparent;
-    margin: auto;
-    --bs-modal-padding: 1rem;
-    --bs-modal-bg: var(--bs-body-bg);
-    --bs-modal-color: var(--bs-body-color);
-    --bs-modal-border-color: var(--bs-border-color);
-    --bs-modal-border-width: var(--bs-border-width);
-    --bs-modal-border-radius: var(--bs-border-radius-lg);
-    --bs-modal-inner-border-radius: calc(var(--bs-border-radius-lg) - var(--bs-border-width));
-    --bs-modal-header-padding-x: 1rem;
-    --bs-modal-header-padding-y: 1rem;
-    --bs-modal-header-padding: 1rem 1rem;
-    --bs-modal-header-border-color: var(--bs-border-color);
-    --bs-modal-header-border-width: var(--bs-border-width);
-    --bs-modal-title-line-height: 1.5;
-    --bs-modal-footer-gap: 0.5rem;
-    --bs-modal-footer-border-color: var(--bs-border-color);
-    --bs-modal-footer-border-width: var(--bs-border-width);
-}
-
-body:has(dialog.popoverstyling[open]) {
-    overflow: hidden;
-}
-
-dialog.popoverstyling .modal-content {
-    max-height: 85vh;
-    overflow: hidden;
-}
-
-dialog.popoverstyling .modal-body {
-    overflow-y: auto;
-}
-
-dialog.popoverstyling .modal-header .modal-title {
-    font-size: 1rem;
-    font-family: var(--bs-font-sans-serif);
-    margin-bottom: 0;
-}
-
-dialog.popoverstyling .modal-footer .btn {
-    padding: 0.375rem 0.75rem;
-    font-family: var(--bs-font-sans-serif);
-}
-
-dialog.popoverstyling .modal-body h3,
-dialog.popoverstyling .modal-body h4 {
-    margin-top: 1.75rem;
-}
-
-dialog.popoverstyling .modal-body > h3:first-child {
-    margin-top: 0;
-}
-
-dialog.popoverstyling .modal-body table {
-    width: 100%;
-}
-
-dialog[open] {
-    animation: slide-in-up .3s cubic-bezier(.25, 0, .3, 1);
-}
-
-dialog::backdrop { }
-
-@keyframes slide-in-up {
-    0% { transform: translateY(100%); }
-}
-
-/* Dark mode — indigo-slate theme */
-[data-bs-theme=dark] {
-    --bs-body-bg: #1a1b2e;
-    --bs-body-bg-rgb: 26, 27, 46;
-    --bs-body-secondary-bg: #13141f;
-    --bs-border-color: rgba(255, 255, 255, 0.07);
-}@charset "UTF-8";
+@charset "UTF-8";
 /*!
  * Bootstrap  v5.3.2 (https://getbootstrap.com/)
  * Copyright 2011-2023 The Bootstrap Authors
@@ -23114,3 +19978,3145 @@ readers do not read off random characters that represent icons */
   font-display: block;
   src: url("../webfonts/fa-v4compatibility.woff2") format("woff2"), url("../webfonts/fa-v4compatibility.ttf") format("truetype");
   unicode-range: U+F041,U+F047,U+F065-F066,U+F07D-F07E,U+F080,U+F08B,U+F08E,U+F090,U+F09A,U+F0AC,U+F0AE,U+F0B2,U+F0D0,U+F0D6,U+F0E4,U+F0EC,U+F10A-F10B,U+F123,U+F13E,U+F148-F149,U+F14C,U+F156,U+F15E,U+F160-F161,U+F163,U+F175-F178,U+F195,U+F1F8,U+F219,U+F27A; }
+/* This file is maintaned in https://github.com/ScanGov/components and copied to multiple projects during startup */
+
+/* Fonts */
+
+@font-face {
+    font-family: "Public Sans ExtraBold";
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-ExtraBold.ttf") format("truetype");
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "Public Sans Bold";
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-Bold.ttf") format("truetype");
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "Public Sans Regular";
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-Regular.ttf") format("truetype");
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "Public Sans Light";
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-Light.ttf") format("truetype");
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "Public Sans Thin";
+    src: url("/assets/fonts/public-sans/ttf/PublicSans-Thin.ttf") format("truetype");
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "JetBrains Mono Regular";
+    src: local("JetBrains Mono"), url("/assets/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf") format("truetype");
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "JetBrains Mono Medium";
+    src: url("/assets/fonts/jetbrains-mono/JetBrainsMono-Medium.ttf") format("truetype");
+    font-display: swap;
+}
+
+@font-face {
+    font-family: "JetBrains Mono ExtraBold";
+    src: url("/assets/fonts/jetbrains-mono/JetBrainsMono-ExtraBold.ttf") format("truetype");
+    font-display: swap;
+}
+
+/* Dark mode (default) */
+
+:root, [data-bs-theme=dark] {
+    color-scheme: dark;
+    --bs-primary: #4FB8F0;
+    --bs-primary-rgb: 79, 184, 240;
+    --bs-primary-text: #13171f;
+    --bs-body-color: #fff;
+    --bs-body-color-rgb: 255, 255, 255;
+    --bs-body-bg: #13171f;
+    --bs-body-bg-rgb: 19, 23, 31;
+    --bs-body-secondary-bg: #0f1218;
+    --bs-link-color: #4FB8F0;
+    --bs-link-color-rgb: 79, 184, 240;
+    --bs-link-hover-color: var(--bs-link-color);
+    --bs-link-hover-color-rgb: 79, 184, 240;
+    --bs-link-hover-decoration: none;
+    --bs-highlight-bg: var(--bs-primary);
+    --bs-highlight-color: var(--bs-primary-text);
+    --bs-selection-bg: var(--bs-primary);
+    --bs-selection-color: var(--bs-primary-text);
+    --bs-btn-primary: var(--bs-primary);
+    --bs-btn-primary-color: var(--bs-primary-text);
+    --bs-btn-primary-border-color: var(--bs-primary);
+    --bs-btn-primary-focus-shadow-rgb: 79, 184, 240;
+    --bs-btn-primary-active-shadow-rgb: 79, 184, 240;
+    --bs-btn-primary-active-color: var(--bs-primary-text);
+    --bs-btn-primary-active-bg: var(--bs-primary);
+    --bs-btn-primary-bg: var(--bs-primary);
+    --bs-btn-bg: var(--bs-primary);
+    --bs-btn-border-color: var(--bs-primary);
+    --bs-btn-color: var(--bs-primary-text);
+    --bs-btn-hover-bg: var(--bs-primary);
+    --bs-btn-hover-border-color: var(--bs-primary);
+    --bs-btn-hover-color: var(--bs-primary-text);
+    --bs-nav-link-color: var(--bs-body-color);
+    --bs-nav-link-hover-color: var(--bs-link-color);
+    --bs-border-color: #252f3e;
+    --bs-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
+    --bs-card-shadow: var(--bs-shadow);
+    --bs-box-shadow: var(--bs-shadow);
+    --bs-box-shadow-md: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.5);
+    --bs-secondary: var(--bs-body-color);
+    --bs-text-secondary: var(--bs-secondary);
+    --bs-badge-bg: var(--bs-primary);
+    --bs-badge-font-weight: 300;
+    --bs-border-radius-sm: .25rem;
+    /* WCAG 2.2 AA: #face00 on #13171f = 11.87:1 ✓ */
+    --bs-text-bg-primary: #face00;
+    --bs-info-text-emphasis: var(--bs-body-color);
+    --bs-info-bg-subtle: var(--bs-body-secondary-bg);
+    --bs-info-border-subtle: var(--bs-border-color);
+    --bs-primary-bg-subtle: #0a1929;
+    --bs-primary-border-subtle: #1d4ed8;
+    --bs-primary-text-emphasis: #93c5fd;
+    --bs-text-muted: var(--bs-body-color);
+    --bs-font-monospace: "JetBrains Mono Regular", monospace;
+    --bs-font-light: "Public Sans Light", sans-serif;
+    --bs-font-bold: "Public Sans Bold", sans-serif;
+    --bs-font-regular: "Public Sans Regular", sans-serif;
+    --bs-font-sans-serif: "Public Sans Regular", sans-serif;
+    --bs-text-opacity: .5;
+    --bs-emphasis-color: var(--bs-body-color);
+    --bs-form-control-color: var(--bs-body-color);
+    --bs-form-control-bg: var(--bs-body-bg);
+    --bs-form-control-border-color: var(--bs-border-color);
+    --bs-form-control-focus-border-color: var(--bs-primary);
+    --bs-form-control-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
+    --bs-form-control-focus-color: var(--bs-body-color);
+    --bs-card-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
+    /* Status colors */
+    --bs-success: #70e17b;
+    --bs-bg-success: #70e17b;
+    --bs-bg-success-rgb: 112, 225, 123;
+    --bs-border-success: #70e17b;
+    --bs-warning: #face00;
+    --bs-text-warning: #000000;
+    --bs-bg-warning: #face00;
+    --bs-bg-warning-rgb: 250, 206, 0;
+    --bs-border-warning: #face00;
+    --bs-danger: #e41d3d;
+    --bs-text-danger: #ffffff;
+    --bs-bg-danger: #e41d3d;
+    --bs-bg-danger-rgb: 228, 29, 61;
+    --bs-border-danger: #e41d3d;
+}
+
+/* Light mode */
+
+[data-bs-theme=light] {
+    color-scheme: light;
+    --bs-primary: #2563eb;
+    --bs-primary-rgb: 37, 99, 235;
+    --bs-primary-text: #ffffff;
+    --bs-body-color: #13171f;
+    --bs-body-color-rgb: 19, 23, 31;
+    --bs-body-bg: #ffffff;
+    --bs-body-bg-rgb: 255, 255, 255;
+    --bs-body-secondary-bg: #f4f6f9;
+    /* WCAG 2.2 AA: #2563eb on #fff = 4.66:1 ✓ */
+    --bs-link-color: #2563eb;
+    --bs-link-color-rgb: 37, 99, 235;
+    --bs-link-hover-color: var(--bs-link-color);
+    --bs-link-hover-color-rgb: 37, 99, 235;
+    --bs-link-hover-decoration: none;
+    --bs-highlight-bg: var(--bs-primary);
+    --bs-highlight-color: var(--bs-primary-text);
+    --bs-selection-bg: var(--bs-primary);
+    --bs-selection-color: var(--bs-primary-text);
+    --bs-btn-primary: var(--bs-primary);
+    --bs-btn-primary-color: var(--bs-primary-text);
+    --bs-btn-primary-border-color: var(--bs-primary);
+    --bs-btn-primary-focus-shadow-rgb: 37, 99, 235;
+    --bs-btn-primary-active-shadow-rgb: 37, 99, 235;
+    --bs-btn-primary-active-color: var(--bs-primary-text);
+    --bs-btn-primary-active-bg: var(--bs-primary);
+    --bs-btn-primary-bg: var(--bs-primary);
+    --bs-btn-bg: var(--bs-primary);
+    --bs-btn-border-color: var(--bs-primary);
+    --bs-btn-color: var(--bs-primary-text);
+    --bs-btn-hover-bg: var(--bs-primary);
+    --bs-btn-hover-border-color: var(--bs-primary);
+    --bs-btn-hover-color: var(--bs-primary-text);
+    --bs-nav-link-color: var(--bs-body-color);
+    --bs-nav-link-hover-color: var(--bs-link-color);
+    --bs-border-color: #d5dce8;
+    --bs-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.06);
+    --bs-card-shadow: var(--bs-shadow);
+    --bs-box-shadow: var(--bs-shadow);
+    --bs-box-shadow-md: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.15);
+    --bs-secondary: var(--bs-body-color);
+    --bs-text-secondary: var(--bs-secondary);
+    --bs-badge-bg: var(--bs-primary);
+    --bs-badge-font-weight: 300;
+    --bs-border-radius-sm: .25rem;
+    /* WCAG 2.2 AA: #fff on #2563eb = 4.66:1 ✓ */
+    --bs-text-bg-primary: #2563eb;
+    --bs-info-text-emphasis: var(--bs-body-color);
+    --bs-info-bg-subtle: var(--bs-body-secondary-bg);
+    --bs-info-border-subtle: var(--bs-border-color);
+    --bs-primary-bg-subtle: #dbeafe;
+    --bs-primary-border-subtle: #3b82f6;
+    --bs-primary-text-emphasis: #1e3a8a;
+    /* WCAG 2.2 AA: #4a5568 on #fff = 7.53:1 ✓ */
+    --bs-text-muted: #4a5568;
+    --bs-text-opacity: .5;
+    --bs-emphasis-color: var(--bs-body-color);
+    --bs-form-control-color: var(--bs-body-color);
+    --bs-form-control-bg: var(--bs-body-bg);
+    --bs-form-control-border-color: var(--bs-border-color);
+    --bs-form-control-focus-border-color: var(--bs-primary);
+    --bs-form-control-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
+    --bs-form-control-focus-color: var(--bs-body-color);
+    --bs-card-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
+    /* font vars, status colors inherited from :root */
+}
+
+/* Status badge overrides */
+
+/* WCAG 2.2 AA: #13171f on #70e17b = 8.19:1 ✓ */
+.text-bg-success {
+    color: #13171f !important;
+    background-color: #70e17b !important;
+}
+
+/* WCAG 2.2 AA: #000 on #face00 = 15.18:1 ✓ */
+.text-bg-warning {
+    color: #000000 !important;
+    background-color: #face00 !important;
+}
+
+/* WCAG 2.2 AA: #fff on #e41d3d = 4.73:1 ✓ */
+.text-bg-danger {
+    color: #ffffff !important;
+    background-color: #e41d3d !important;
+}
+
+.text-bg-primary {
+    background-color: var(--bs-text-bg-primary) !important;
+    color: var(--bs-body-bg) !important;
+}
+
+/* Footer */
+
+footer a:hover {
+    color: var(--bs-link-color) !important;
+    text-decoration: underline;
+}
+
+footer p.small a {
+    text-decoration: underline;
+}
+
+footer p.small a:hover {
+    text-decoration: none;
+}
+
+/* Theme-dependent: logo/image invert */
+
+:root body footer img,
+:root body ul.navbar-nav img,
+[data-bs-theme=dark] body footer img,
+[data-bs-theme=dark] body ul.navbar-nav img {
+    filter: invert(1);
+}
+
+[data-bs-theme=light] body footer img,
+[data-bs-theme=light] body ul.navbar-nav img {
+    filter: none;
+}
+
+/* Theme-dependent: navbar toggler icon */
+
+[data-bs-theme="light"] .navbar-toggler-icon {
+    --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2819, 23, 31, 1%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+[data-bs-theme="dark"] .navbar-toggler-icon {
+    --bs-navbar-toggler-icon-bg: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 1%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+/* Theme-dependent: text-secondary */
+
+.text-secondary {
+    color: rgba(19, 23, 31, var(--bs-text-opacity)) !important;
+}
+
+[data-bs-theme=dark] .text-secondary {
+    color: rgba(255, 255, 255, var(--bs-text-opacity)) !important;
+}
+
+/* General */
+
+blockquote {
+    padding: 1rem 1rem .5rem 1rem;
+    margin: 1rem 0 1rem 0;
+    border-left: 0.25rem solid var(--bs-border-color);
+    font-size: 1.25rem;
+}
+
+.text-muted {
+    color: var(--bs-body-color) !important;
+}
+
+body {
+    color: var(--bs-body-color);
+    background-color: var(--bs-body-bg) !important;
+    font-family: var(--bs-font-sans-serif);
+    line-height: 1.5;
+}
+
+strong {
+    font-family: var(--bs-font-bold);
+}
+
+.display-4, .display-5, .display-6 {
+    text-wrap: balance;
+}
+
+#main-content>.container {
+    margin-top: 1.5rem;
+}
+
+.navbar-brand,
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6,
+.display-1, .display-2, .display-3, .display-4 {
+    font-family: var(--bs-font-bold);
+    letter-spacing: -.01rem;
+}
+
+body.docs h2,
+body.page h2,
+body.post h2,
+body.default h2 {
+    margin-bottom: 1rem;
+    margin-top: 3rem;
+}
+
+body.docs h3,
+body.page h3,
+body.post h3,
+body.default h3 {
+    margin-bottom: 0.75rem;
+    margin-top: 2.5rem;
+}
+
+body.docs h4,
+body.page h4,
+body.post h4,
+body.default h4,
+body.docs h5,
+body.page h5,
+body.post h5,
+body.default h5,
+body.docs h6,
+body.page h6,
+body.post h6,
+body.default h6 {
+    margin-bottom: 0.5rem;
+    margin-top: 2rem;
+}
+
+/* Alert headings */
+
+.alert h1,
+.alert h2,
+.alert h3,
+.alert h4,
+.alert h5,
+.alert h6 {
+    margin-top: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+/* Lead */
+
+.lead {
+    font-family: var(--bs-font-regular) !important;
+    font-size: 1.25rem;
+    font-weight: 300;
+    color: var(--bs-body-color);
+}
+
+/* Selection */
+
+::selection {
+    background-color: var(--bs-selection-bg);
+    color: var(--bs-selection-color);
+}
+
+/* Accessibility */
+
+/* Focus indicators (WCAG 2.4.7, 2.4.11) */
+:focus-visible {
+    outline: 3px solid var(--bs-link-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* Remove outline on mouse/touch click, keep for keyboard (WCAG 2.4.7) */
+:focus:not(:focus-visible) {
+    outline: none;
+}
+
+/* Minimum touch target size (WCAG 2.5.8) — exclude card children to avoid layout shift */
+a:not(.card):not(.card *):not(.stretched-link),
+button:not(.card *) {
+    min-height: 24px;
+    min-width: 24px;
+}
+
+/* Reduced motion (WCAG 2.3.3) */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+/* High contrast mode (WCAG 1.4.11) */
+@media (forced-colors: active) {
+    * {
+        forced-color-adjust: auto;
+    }
+}
+
+/* Skip link — visible on focus for keyboard users (WCAG 2.4.1) */
+.skip-link {
+    position: absolute;
+    top: -100%;
+    left: 0;
+}
+
+.skip-link:focus {
+    top: 0;
+}
+
+/* Navbar */
+
+#logo {
+    max-width: 35px;
+    width: 100%;
+    height: 100%;
+}
+
+.navbar {
+    box-shadow: var(--bs-shadow);
+    transition: box-shadow 0.25s ease;
+    --bs-navbar-padding-y: 0.5rem;
+    --bs-navbar-padding-x: 0;
+    --bs-nav-link-padding-y: 0.5rem;
+    --bs-nav-link-padding-x: 1rem;
+    --bs-nav-link-font-size: 1.1em;
+}
+
+.navbar-brand {
+    font-family: var(--bs-font-bold);
+    color: var(--bs-body-color) !important;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.navbar-brand>svg {
+    fill: var(--bs-body-color) !important;
+}
+
+.navbar-brand:hover {
+    color: var(--bs-link-color) !important;
+}
+
+.navbar-brand:hover>svg {
+    fill: var(--bs-link-color) !important;
+}
+
+.navbar-toggler-icon {
+    color: var(--bs-body-color) !important;
+}
+
+.navbar-nav,
+.navbar-nav .nav-link:not(.active),
+a.list-group-item {
+    color: var(--bs-body-color) !important;
+    font-family: "Public Sans Regular", sans-serif !important;
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
+}
+
+.navbar-nav .nav-link.active {
+    padding-top: 0.65rem;
+    padding-bottom: 0.65rem;
+}
+
+.nav-link {
+    font-family: "Public Sans Regular", sans-serif !important;
+}
+
+.navbar-nav .nav-link:not(.active):hover,
+a.list-group-item:hover {
+    color: var(--bs-link-color) !important;
+}
+
+a.list-group-item:hover {
+    background-color: var(--bs-body-secondary-bg);
+}
+
+.border-end {
+    box-shadow: var(--bs-shadow);
+}
+
+/* Social links */
+
+.social a, .social a:visited {
+    color: var(--bs-body-color);
+    display: inline-block;
+    margin-right: .75rem;
+}
+
+.social a:hover {
+    color: var(--bs-link-color);
+}
+
+/* External link icon (post/page content) */
+
+.post-content a[href^="http"]:not([href^="https://scangov.org"]):not([href^="https://standards.scangov.org"]):not([href^="https://scangov.com"]):not([href^="https://my.scangov.com"]):not([href^="https://data.scangov.org"]):not([href^="http://localhost:4000/"]):not([href^="https://docs.scangov.org"])::after,
+.page-content a[href^="http"]:not([href^="https://scangov.org"]):not([href^="https://standards.scangov.org"]):not([href^="https://scangov.com"]):not([href^="https://my.scangov.com"]):not([href^="https://data.scangov.org"]):not([href^="http://localhost:4000/"]):not([href^="https://docs.scangov.org"])::after {
+    content: '';
+    display: inline-block;
+    width: 0.65em;
+    height: 0.65em;
+    margin-left: 0.25em;
+    vertical-align: text-top;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%237efbe1' d='M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6l0-128c0-17.7-14.3-32-32-32L352 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+[data-bs-theme=light] .post-content a[href^="http"]:not([href^="https://scangov.org"]):not([href^="https://standards.scangov.org"]):not([href^="https://scangov.com"]):not([href^="https://my.scangov.com"]):not([href^="https://data.scangov.org"]):not([href^="http://localhost:4000/"]):not([href^="https://docs.scangov.org"])::after,
+[data-bs-theme=light] .page-content a[href^="http"]:not([href^="https://scangov.org"]):not([href^="https://standards.scangov.org"]):not([href^="https://scangov.com"]):not([href^="https://my.scangov.com"]):not([href^="https://data.scangov.org"]):not([href^="http://localhost:4000/"]):not([href^="https://docs.scangov.org"])::after {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cpath fill='%230d7a6e' d='M352 0c-12.9 0-24.6 7.8-29.6 19.8s-2.2 25.7 6.9 34.9L370.7 96 201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L416 141.3l41.4 41.4c9.2 9.2 22.9 11.9 34.9 6.9s19.8-16.6 19.8-29.6l0-128c0-17.7-14.3-32-32-32L352 0zM80 32C35.8 32 0 67.8 0 112L0 432c0 44.2 35.8 80 80 80l320 0c44.2 0 80-35.8 80-80l0-112c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 112c0 8.8-7.2 16-16 16L80 448c-8.8 0-16-7.2-16-16l0-320c0-8.8 7.2-16 16-16l112 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L80 32z'/%3E%3C/svg%3E");
+}
+
+.social a::after {
+    display: none !important;
+}
+
+/* Breadcrumb */
+
+.breadcrumb-item, .breadcrumb-item a, .breadcrumb-item a:visited {
+    color: var(--bs-link-color);
+    font-family: var(--bs-font-monospace);
+    text-decoration: none;
+}
+
+.breadcrumb-profile .breadcrumb-item,
+.breadcrumb-profile .breadcrumb-item a,
+.breadcrumb-profile .breadcrumb-item a:visited {
+    font-size: 1.2rem;
+}
+
+.breadcrumb-item a:hover {
+    text-decoration: underline;
+    color: var(--bs-link-color);
+}
+
+.bc-sep {
+    color: white;
+}
+
+.breadcrumb-item a.bc-org,
+.breadcrumb-item a.bc-org:visited {
+    color: var(--bs-link-color);
+}
+
+.breadcrumb-item a.bc-domain,
+.breadcrumb-item a.bc-domain:visited,
+.breadcrumb-item a.bc-org-current,
+.breadcrumb-item a.bc-org-current:visited {
+    color: white;
+}
+
+[data-bs-theme=light] .bc-sep {
+    color: var(--bs-body-color);
+}
+
+[data-bs-theme=light] .breadcrumb-item a.bc-org,
+[data-bs-theme=light] .breadcrumb-item a.bc-org:visited {
+    color: var(--bs-link-color);
+}
+
+[data-bs-theme=light] .breadcrumb-item a.bc-domain,
+[data-bs-theme=light] .breadcrumb-item a.bc-domain:visited,
+[data-bs-theme=light] .breadcrumb-item a.bc-org-current,
+[data-bs-theme=light] .breadcrumb-item a.bc-org-current:visited {
+    color: var(--bs-body-color);
+}
+
+/* Default (Bootstrap-style) breadcrumb — no bold, standard colors */
+.breadcrumb-default .breadcrumb-item,
+.breadcrumb-default .breadcrumb-item a,
+.breadcrumb-default .breadcrumb-item a:visited {
+    font-family: inherit;
+}
+
+.breadcrumb-default .breadcrumb-item.active {
+    color: var(--bs-secondary-color);
+}
+
+/* Links / Buttons */
+
+a:hover {
+    text-decoration: var(--bs-link-hover-decoration);
+    color: var(--bs-link-hover-color);
+}
+
+.btn-primary,
+.btn-primary:visited {
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-radius: var(--bs-border-radius);
+    border: 1px solid var(--bs-primary) !important;
+    box-shadow: var(--bs-shadow);
+    cursor: pointer;
+    font-family: var(--bs-font-bold);
+    padding: 0.5rem 0.875rem;
+    transition: filter 0.25s ease, box-shadow 0.25s ease;
+}
+
+.btn-primary.btn-lg {
+    padding: 0.625rem 1.25rem;
+}
+
+.btn-primary.btn-sm {
+    padding: 0.3rem 0.6rem;
+}
+
+a.btn-primary-outline,
+button.btn-primary-outline {
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    border-radius: var(--bs-border-radius-sm);
+    border: 1px solid var(--bs-border-color);
+    box-shadow: var(--bs-shadow);
+    cursor: pointer;
+    font-family: var(--bs-font-sans-serif);
+    padding: 0.5rem 0.875rem;
+    transition: filter 0.25s ease, box-shadow 0.25s ease;
+}
+
+button.btn-primary-outline:hover,
+button.btn-primary-outline:focus {
+    color: var(--bs-body-bg) !important;
+}
+
+.btn-primary-outline:hover i,
+.btn-primary-outline:hover svg {
+    color: inherit !important;
+}
+
+.btn.btn-outline-primary {
+    --bs-btn-color: var(--bs-body-color);
+    --bs-btn-border-color: var(--bs-border-color);
+    --bs-btn-hover-color: var(--bs-body-bg);
+    --bs-btn-hover-bg: var(--bs-body-color);
+    --bs-btn-hover-border-color: var(--bs-body-color);
+    --bs-btn-active-color: var(--bs-body-bg);
+    --bs-btn-active-bg: var(--bs-body-color);
+    --bs-btn-active-border-color: var(--bs-body-color);
+    padding: 0.5rem 0.875rem;
+}
+
+.btn.btn-outline-primary.btn-lg {
+    padding: 0.625rem 1.25rem;
+}
+
+.btn.btn-outline-primary.btn-sm {
+    padding: 0.3rem 0.6rem;
+}
+
+.btn.btn-outline-primary:not(.btn-lg) {
+    margin-top: 1rem;
+}
+
+.btn.btn-outline-primary i,
+.btn.btn-outline-primary svg {
+    color: inherit !important;
+}
+
+.btn.btn-outline-primary .fa-sitemap {
+    color: #ffbc78 !important;
+}
+
+.btn.btn-outline-primary:hover .fa-sitemap,
+.btn.btn-outline-primary:focus .fa-sitemap {
+    color: inherit !important;
+}
+
+.btn[download] {
+    margin-right: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.feedback {
+    opacity: 0;
+    pointer-events: none;
+    visibility: hidden;
+    background-color: var(--bs-primary);
+    color: var(--bs-primary-text) !important;
+    border-radius: var(--bs-border-radius);
+    border: 1px solid var(--bs-primary);
+    box-shadow: var(--bs-shadow);
+    cursor: pointer;
+    font-family: var(--bs-font-bold);
+    position: fixed;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    text-decoration: none;
+    transition: opacity 0.25s ease, visibility 0.25s ease, filter 0.25s ease, box-shadow 0.25s ease;
+}
+
+.feedback.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+    visibility: visible;
+}
+
+.btn-primary i, .btn-primary svg,
+.feedback i, .feedback svg {
+    color: inherit !important;
+    transition: filter 0.25s ease;
+}
+
+.btn-primary:hover, .btn-primary:focus,
+.feedback:hover, .feedback:focus {
+    filter: brightness(1.3);
+    box-shadow: var(--bs-box-shadow-md);
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+}
+
+a.btn-primary-outline:not(.active):hover,
+.btn-primary-outline:not(.active):hover,
+a.btn-primary-outline:not(.active):focus,
+a.btn-primary-outline.active,
+.btn-primary-outline.active {
+    filter: brightness(1.3);
+    box-shadow: var(--bs-box-shadow-md);
+    border: 1px solid var(--bs-border-color);
+}
+
+@media (max-width: 767.98px) {
+    .feedback {
+        font-size: 0.875rem;
+    }
+}
+
+/* js-triggered Bootstrap classes */
+.btn-check:checked+.btn,
+.btn.active:not(.nav-link),
+.btn.show,
+.btn:first-child:active,
+:not(.btn-check)+.btn:active {
+    color: var(--bs-btn-active-color);
+    background-color: var(--bs-btn-active-bg);
+    border-color: var(--bs-btn-active-border-color);
+}
+
+/* Nav pills */
+
+.nav-pills {
+    --bs-nav-pills-link-active-bg: var(--bs-primary);
+    --bs-nav-link-hover-border-color: #1a2130;
+}
+
+[data-bs-theme=light] .nav-pills {
+    --bs-nav-link-hover-border-color: #b0bac8;
+}
+
+.nav-pills .nav-link svg {
+    flex-shrink: 0;
+    width: 1em;
+    height: 1em;
+}
+
+.nav-pills .nav-link {
+    border: 1px solid var(--bs-border-color);
+    box-shadow: var(--bs-shadow);
+    font-family: "Public Sans Regular", sans-serif !important;
+    color: var(--bs-body-color);
+    background-color: var(--bs-body-bg);
+    transition: filter 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    margin-top: 0.35rem;
+    margin-bottom: 0.35rem;
+    display: inline-flex !important;
+    align-items: center;
+    width: auto;
+    flex-shrink: 0;
+}
+
+.nav-pills .nav-link:not(.active):hover,
+.nav-pills a.btn-primary-outline:not(.active):hover {
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+    box-shadow: var(--bs-shadow);
+}
+
+.nav-pills .nav-link:not(.active):hover i,
+.nav-pills .nav-link:not(.active):hover svg {
+    color: var(--bs-primary-text) !important;
+}
+
+.nav-pills .nav-link:not(.active):hover svg path {
+    fill: var(--bs-primary-text) !important;
+}
+
+.nav-pills .nav-link.active i,
+.nav-pills .nav-link.active:hover i,
+.nav-pills .nav-link.active svg,
+.nav-pills .nav-link.active:hover svg {
+    color: var(--bs-primary-text) !important;
+}
+
+/* Nav pills active — var(--bs-primary-text) on var(--bs-primary) (both themes) */
+.nav-pills .nav-link.active,
+.nav-pills .nav-link.active:focus,
+.nav-pills a.btn-primary-outline.active,
+.nav-pills a.btn-primary-outline.active:focus,
+[data-bs-theme=light] .nav-pills .nav-link.active,
+[data-bs-theme=light] .nav-pills .nav-link.active:focus,
+[data-bs-theme=light] .nav-pills a.btn-primary-outline.active,
+[data-bs-theme=light] .nav-pills a.btn-primary-outline.active:focus {
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+    box-shadow: var(--bs-shadow);
+}
+
+.nav-pills .nav-link.active:hover,
+.nav-pills a.btn-primary-outline.active:hover,
+[data-bs-theme=light] .nav-pills .nav-link.active:hover,
+[data-bs-theme=light] .nav-pills a.btn-primary-outline.active:hover {
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+    filter: brightness(1.3);
+    box-shadow: var(--bs-box-shadow-md);
+}
+
+.nav-pills .fa-bars-progress {
+    color: var(--bs-primary) !important;
+}
+
+.nav-pills .fa-certificate {
+    color: #ffbe2e !important;
+}
+
+.nav-pills .fa-diagram-project {
+    color: #7efbe1 !important;
+}
+
+.nav-pills .fa-file-lines {
+    color: #a8f2ff !important;
+}
+
+.nav-pills .fa-database {
+    color: #a8f5d5 !important;
+}
+
+.nav-pills .nav-link.active i,
+.nav-pills .nav-link.active svg,
+.nav-pills a.btn-primary-outline.active i,
+.nav-pills a.btn-primary-outline.active svg,
+[data-bs-theme=light] .nav-pills .nav-link.active i,
+[data-bs-theme=light] .nav-pills .nav-link.active svg,
+[data-bs-theme=light] .nav-pills a.btn-primary-outline.active i,
+[data-bs-theme=light] .nav-pills a.btn-primary-outline.active svg {
+    color: var(--bs-primary-text) !important;
+}
+
+.nav-pills .active {
+    --bs-link-color: var(--bs-body-bg);
+}
+
+/* Profile leftnav active state — same treatment as filter pills */
+.list-group-item.active,
+.list-group-item.active:focus,
+[data-bs-theme=light] .list-group-item.active,
+[data-bs-theme=light] .list-group-item.active:focus {
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+}
+
+.list-group-item.active:hover,
+[data-bs-theme=light] .list-group-item.active:hover {
+    color: var(--bs-primary-text) !important;
+    filter: brightness(1.3);
+}
+
+.list-group-item.active i,
+.list-group-item.active svg,
+[data-bs-theme=light] .list-group-item.active i,
+[data-bs-theme=light] .list-group-item.active svg {
+    color: var(--bs-primary-text) !important;
+}
+
+/* Topic filter pills (standards/guidance switcher, rankings/map tabs, etc.) */
+
+.filter {
+    margin-bottom: 1rem;
+}
+
+.filter .nav-link i,
+.filter .nav-link svg {
+    margin-right: 0.5rem;
+}
+
+.nav-tabs.filter {
+    border-bottom: var(--bs-border-width) solid var(--bs-border-color);
+}
+
+.nav-tabs.filter .nav-link {
+    border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
+    border: 1px solid var(--bs-border-color);
+    border-bottom: 0;
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    margin-bottom: 0;
+    transition: background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.nav-tabs.filter .nav-link:not(.active):hover {
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+    box-shadow: var(--bs-shadow);
+}
+
+.nav-tabs.filter .nav-link:not(.active):hover i,
+.nav-tabs.filter .nav-link:not(.active):hover svg,
+.nav-tabs.filter .nav-link:not(.active):hover [class*="fa-"] {
+    color: var(--bs-primary-text) !important;
+}
+
+.nav-tabs.filter .nav-link.active,
+.nav-tabs.filter .nav-link.active:focus {
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+}
+
+.nav-tabs.filter .nav-link.active i,
+.nav-tabs.filter .nav-link.active svg,
+.nav-tabs.filter .nav-link.active:hover i,
+.nav-tabs.filter .nav-link.active:hover svg {
+    color: var(--bs-primary-text) !important;
+}
+
+.nav-tabs.filter .nav-link.active:hover {
+    filter: brightness(1.3);
+}
+
+/* Top nav tabs */
+
+.nav-tabs.topnav {
+    border-bottom: 0;
+}
+
+.nav-tabs.topnav .nav-link {
+    border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
+    border: 1px solid var(--bs-border-color);
+    border-bottom: 0;
+    padding-top: 0.15rem;
+    padding-bottom: 0.15rem;
+    margin-bottom: 0;
+    color: var(--bs-body-color);
+    transition: background-color 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+}
+
+.nav-tabs.topnav .nav-link:not(.active):hover {
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+}
+
+.nav-tabs.topnav .nav-link.active,
+.nav-tabs.topnav .nav-link.active:focus {
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+}
+
+.nav-tabs.topnav .nav-link.active i,
+.nav-tabs.topnav .nav-link.active svg {
+    color: var(--bs-primary-text) !important;
+}
+
+.nav-tabs.topnav .nav-link.active:hover {
+    filter: brightness(1.3);
+}
+
+/* Per-icon colors (dark mode default) */
+.nav-tabs.topnav .nav-link:not(.active) .fa-bars-progress {
+    color: var(--bs-primary) !important;
+}
+
+.nav-tabs.topnav .nav-link:not(.active) .fa-certificate {
+    color: #ffbe2e !important;
+}
+
+.nav-tabs.topnav .nav-link:not(.active) .fa-diagram-project {
+    color: #7efbe1 !important;
+}
+
+.nav-tabs.topnav .nav-link:not(.active) .fa-file-lines {
+    color: #a8f2ff !important;
+}
+
+.nav-tabs.topnav .nav-link:not(.active) .fa-database {
+    color: #a8f5d5 !important;
+}
+
+/* Per-icon colors (light mode) */
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-bars-progress {
+    color: #8a4f00 !important;
+}
+
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-certificate {
+    color: #8a6500 !important;
+}
+
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-diagram-project {
+    color: #0d7a6e !important;
+}
+
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-file-lines {
+    color: #1a6fa0 !important;
+}
+
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active) .fa-database {
+    color: #0d6b52 !important;
+}
+
+/* Hover overrides for per-icon colors — must come after default icon rules, with :hover for higher specificity */
+.nav-tabs.topnav .nav-link:not(.active):hover .fa-bars-progress,
+.nav-tabs.topnav .nav-link:not(.active):hover .fa-certificate,
+.nav-tabs.topnav .nav-link:not(.active):hover .fa-diagram-project,
+.nav-tabs.topnav .nav-link:not(.active):hover .fa-file-lines,
+.nav-tabs.topnav .nav-link:not(.active):hover .fa-database {
+    color: var(--bs-primary-text) !important;
+}
+
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-bars-progress,
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-certificate,
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-diagram-project,
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-file-lines,
+[data-bs-theme=light] .nav-tabs.topnav .nav-link:not(.active):hover .fa-database {
+    color: var(--bs-primary-text) !important;
+}
+
+/* Pagination */
+
+.page-link {
+    color: inherit;
+    background-color: transparent;
+    border-color: var(--bs-border-color);
+}
+
+.page-link:hover {
+    color: var(--bs-primary-text);
+    background-color: var(--bs-primary);
+    border-color: var(--bs-primary);
+}
+
+.active>.page-link,
+.page-link.active {
+    background-color: var(--bs-primary);
+    border-color: var(--bs-primary);
+    color: var(--bs-primary-text);
+}
+
+.page-item.disabled .page-link {
+    color: var(--bs-secondary-color);
+    background-color: transparent;
+    border-color: var(--bs-border-color);
+}
+
+[data-bs-theme=light] .page-link {
+    color: inherit;
+}
+
+[data-bs-theme=light] .page-link:hover,
+[data-bs-theme=light] .active>.page-link,
+[data-bs-theme=light] .page-link.active {
+    color: var(--bs-primary-text);
+}
+
+/* Sortable tables */
+th.sortable {
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+/* Default table styling: border, hover, and shadow without per-table modifier
+   classes. Excludes dense .table-sm data tables, which stay minimal. */
+.table:not(.table-sm) > :not(caption) > * {
+    border-width: var(--bs-border-width) 0;
+}
+
+.table:not(.table-sm) > :not(caption) > * > * {
+    border-width: 0 var(--bs-border-width);
+}
+
+.table:not(.table-sm) > tbody > tr:hover > * {
+    --bs-table-color-state: var(--bs-table-hover-color);
+    --bs-table-bg-state: var(--bs-table-hover-bg);
+}
+
+.table:not(.table-sm) {
+    box-shadow: var(--bs-box-shadow);
+    font-size: 0.95rem;
+}
+
+/* Rankings table */
+
+.rankings-col-site {
+    word-break: break-word;
+}
+
+/* Dropdown */
+
+.dropdown-toggle::after {
+    display: none;
+}
+
+.dropdown-toggle svg {
+    color: var(--bs-btn-color) !important;
+    transition: 0.15s color;
+}
+
+.dropdown-toggle:hover svg,
+.dropdown-toggle:focus svg {
+    color: var(--bs-btn-hover-color) !important;
+}
+
+/* Code blocks */
+
+.highlighter-rouge {
+    margin-bottom: 1rem;
+}
+
+code.language-plaintext {
+    background-color: var(--bs-tertiary-bg);
+    border-radius: 0.2rem;
+    font-family: var(--bs-font-monospace);
+    font-size: 0.875em;
+    padding: 0.1em 0.35em;
+}
+
+/* Page actions (Rescan / Download / Share) */
+
+.actions>li>a,
+.actions>li>button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 0.9rem;
+    color: var(--bs-body-color);
+    text-decoration: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.actions>li>a small,
+.actions>li>button small {
+    border-left: 1px solid var(--bs-border-color);
+    padding-left: 0.5rem;
+    align-self: stretch;
+    display: inline-flex;
+    align-items: center;
+}
+
+.actions>li>a:hover,
+.actions>li>a:focus,
+.actions>li>button:hover,
+.actions>li>button:focus {
+    color: var(--bs-link-color);
+}
+
+.actions .list-group-item:hover {
+    background-color: var(--bs-body-secondary-bg);
+}
+
+.actions .dropdown-item {
+    border-bottom: 1px solid var(--bs-border-color);
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
+
+.actions .dropdown-menu li:last-child .dropdown-item {
+    border-bottom: none;
+}
+
+.actions .dropdown-item:hover,
+.actions .dropdown-item:focus {
+    background-color: transparent;
+    color: var(--bs-link-color);
+}
+
+.input-group>.btn:not(:first-child) {
+    border-top-right-radius: var(--bs-border-radius-lg) !important;
+    border-bottom-right-radius: var(--bs-border-radius-lg) !important;
+}
+
+.dropdown-menu.show {
+    display: block;
+}
+
+/* Badge */
+
+.badge {
+    font-family: "Public Sans Regular", sans-serif !important;
+    padding: .55rem !important;
+    font-size: .8rem !important;
+    font-weight: 300;
+    border-radius: var(--bs-border-radius-sm) !important;
+}
+
+.badge-primary:hover {
+    background-color: #fee685 !important;
+    /* WCAG 2.2 AA: #13171f on #fee685 = 14.42:1 ✓ */
+    color: #13171f !important;
+}
+
+/* Page sections */
+
+.page-section {
+    padding-bottom: 3rem;
+    margin-bottom: 3rem;
+    border-bottom: 1px solid var(--bs-border-color);
+}
+
+.page-section:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 0;
+}
+
+/* CTA */
+
+.cta {
+    margin-top: 3rem;
+}
+
+.cta .alert {
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+}
+
+.cta .alert h2 {
+    margin-top: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.cta .alert p {
+    margin-bottom: 1.5rem;
+}
+
+/* Cards */
+
+.card {
+    border: 1px solid var(--bs-border-color);
+    box-shadow: var(--bs-shadow);
+    width: 100%;
+    transition: filter 0.25s ease, box-shadow 0.25s ease;
+}
+
+
+.card:focus,
+.card:focus-within {
+    box-shadow: var(--bs-card-focus-box-shadow);
+}
+
+a.card {
+    text-decoration: none;
+}
+
+.card:not(.text-bg-success):not(.text-bg-warning):not(.text-bg-danger):hover {
+    filter: brightness(1.3);
+    box-shadow: var(--bs-box-shadow-md);
+}
+
+[data-bs-theme=light] .card:not(.text-bg-success):not(.text-bg-warning):not(.text-bg-danger):hover {
+    filter: brightness(0.97);
+}
+
+.card-body i+h3 {
+    margin-top: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.card:has(.stretched-link) {
+    border-color: rgba(var(--bs-link-color-rgb), 0.9) !important;
+    opacity: 0.9;
+    transition: border-color 0.2s ease, box-shadow 0.25s ease, opacity 0.2s ease;
+}
+
+.card:has(.stretched-link):hover {
+    border-color: rgba(var(--bs-link-color-rgb), 1) !important;
+    box-shadow: var(--bs-box-shadow-md);
+    opacity: 1;
+    filter: none;
+}
+
+.card-header>a,
+.card-header>a>svg {
+    color: inherit !important;
+}
+
+.card-hover {
+    transition: filter 0.25s ease, box-shadow 0.25s ease;
+}
+
+.card-hover:hover {
+    filter: brightness(1.3);
+    box-shadow: var(--bs-box-shadow-md);
+}
+
+[data-bs-theme=light] .card-hover:hover {
+    filter: brightness(0.97);
+}
+
+/* Status cards — consistent across themes */
+
+.text-bg-success.card {
+    border-color: #70e17b !important;
+}
+
+.text-bg-warning.card {
+    border-color: #face00 !important;
+}
+
+.text-bg-danger.card {
+    border-color: #e41d3d !important;
+}
+
+.text-bg-success.card:hover,
+.text-bg-warning.card:hover,
+.text-bg-danger.card:hover {
+    filter: brightness(1.3);
+    box-shadow: var(--bs-box-shadow-md);
+}
+
+/* Icons and links inside status cards match card text color */
+.card.text-bg-success i, .card.text-bg-success svg,
+.card.text-bg-success a, .card.text-bg-success a:visited, .card.text-bg-success a:hover,
+.card.text-bg-warning i, .card.text-bg-warning svg,
+.card.text-bg-warning a, .card.text-bg-warning a:visited, .card.text-bg-warning a:hover {
+    color: #13171f !important;
+    fill: #13171f !important;
+}
+
+.card.text-bg-danger i, .card.text-bg-danger svg,
+.card.text-bg-danger a, .card.text-bg-danger a:visited, .card.text-bg-danger a:hover {
+    color: #ffffff !important;
+    fill: #ffffff !important;
+}
+
+.text-bg-success .card-header,
+.text-bg-warning .card-header,
+.text-bg-danger .card-header {
+    background-color: rgba(255, 255, 255, 0.15) !important;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.2) !important;
+    padding: 0.75rem 1rem;
+    font-family: var(--bs-font-regular);
+    --bs-card-cap-bg: rgba(255, 255, 255, 0.15);
+}
+
+.text-bg-success .card-body,
+.text-bg-warning .card-body,
+.text-bg-danger .card-body {
+    padding: 1rem;
+}
+
+/* Grade cards */
+
+.card-grade,
+.card-grade-sm {
+    margin-bottom: 0;
+}
+
+.card-grade .card-body {
+    text-align: center;
+    padding-top: 2.5rem;
+    padding-bottom: 2.5rem;
+}
+
+.card-grade-sm .card-body {
+    text-align: center;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
+}
+
+.card-grade-sm .card-body .display-2 {
+    margin-bottom: 0;
+}
+
+/* Forms */
+
+form button[type="submit"],
+form input[type="submit"] {
+    margin-bottom: 2rem;
+}
+
+td form button[type="submit"],
+td form input[type="submit"] {
+    margin-bottom: 0;
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-label .fa-asterisk {
+    margin-left: 0.25rem;
+}
+
+.form-error {
+    color: var(--bs-danger);
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
+    display: none;
+}
+
+.form-control {
+    color: var(--bs-body-color) !important;
+    border: 1px solid var(--bs-border-color);
+    box-shadow: var(--bs-shadow);
+    transition: filter 0.25s ease, box-shadow 0.25s ease;
+}
+
+.form-control:hover {
+    filter: brightness(1.05);
+    box-shadow: var(--bs-box-shadow-md);
+}
+
+.form-control:focus {
+    border-color: var(--bs-primary);
+    box-shadow: var(--bs-form-control-focus-box-shadow);
+    filter: none;
+}
+
+::placeholder, ::-ms-input-placeholder {
+    color: var(--bs-body-color);
+    opacity: var(--bs-text-opacity);
+}
+
+input[type="submit"] {
+    min-width: 80px;
+}
+
+.progress {
+    height: 6px;
+}
+
+/* SVG */
+
+svg {
+    display: inline-block;
+    height: 1em;
+    overflow: visible;
+    vertical-align: -.125em;
+    margin: 0 .3rem;
+    flex-shrink: 0;
+    width: 1em;
+}
+
+svg.sizeicon-xl {
+    height: 1.5em;
+    max-width: 1.5em;
+    line-height: .04167em;
+}
+
+table td svg {
+    margin: 0;
+}
+
+/* FA size classes override the default 1em height */
+.fa-2xs svg {
+    height: 0.625em;
+}
+
+.fa-xs svg {
+    height: 0.75em;
+}
+
+.fa-sm svg {
+    height: 0.875em;
+}
+
+.fa-lg svg {
+    height: 1.25em;
+}
+
+.fa-xl svg {
+    height: 1.5em;
+}
+
+.fa-2xl svg {
+    height: 2em;
+}
+
+.fa-2x svg {
+    height: 2em;
+}
+
+.fa-3x svg {
+    height: 3em;
+}
+
+.fa-4x svg {
+    height: 4em;
+}
+
+.fa-5x svg {
+    height: 5em;
+}
+
+.fa-6x svg {
+    height: 6em;
+}
+
+.fa-7x svg {
+    height: 7em;
+}
+
+.fa-8x svg {
+    height: 8em;
+}
+
+.fa-9x svg {
+    height: 9em;
+}
+
+.fa-10x svg {
+    height: 10em;
+}
+
+svg.fa-circle-check {
+    fill: var(--bs-success);
+}
+
+svg.fa-circle-xmark {
+    fill: var(--bs-danger);
+}
+
+svg.fa-circle-exclamation {
+    fill: var(--bs-warning);
+}
+
+svg.fa-circle-right {
+    fill: var(--bs-info);
+}
+
+svg.fa-arrow-right-arrow-left {
+    fill: var(--bs-warning);
+}
+
+/* Images */
+
+main#home img {
+    display: block;
+    margin: auto;
+    margin-bottom: 0.5rem;
+}
+
+/* Accessibility utilities */
+
+.fa-sr-only, .fa-sr-only-focusable:not(:focus), .sr-only, .sr-only-focusable:not(:focus) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
+.d-none {
+    display: none;
+}
+
+
+/* Timeline */
+
+.timeline {
+    border-left: 1px solid hsl(0, 0%, 90%);
+    position: relative;
+    list-style: none;
+}
+
+.timeline .timeline-item {
+    position: relative;
+}
+
+.timeline .timeline-item:after {
+    position: absolute;
+    display: block;
+    top: 0;
+    background-color: hsl(0, 0%, 90%);
+    left: -38px;
+    border-radius: 50%;
+    height: 11px;
+    width: 11px;
+    content: '';
+}
+
+.timeline-domain {
+    margin-bottom: 0.25rem;
+}
+
+.timeline-date {
+    font-family: var(--bs-font-bold);
+}
+
+/* Anchor links */
+
+a.heading-anchor-text {
+    color: inherit !important;
+    text-decoration: none;
+}
+
+h2 a#heading-hashtag,
+h3 a#heading-hashtag {
+    display: none;
+    color: var(--bs-link-color);
+    text-decoration: none;
+    margin-left: 0.4rem;
+    font-size: 0.75em;
+    vertical-align: middle;
+}
+
+h2 a#heading-hashtag svg,
+h3 a#heading-hashtag svg {
+    color: var(--bs-link-color) !important;
+    fill: var(--bs-link-color) !important;
+}
+
+h2:hover a#heading-hashtag,
+h3:hover a#heading-hashtag {
+    display: inline;
+}
+
+/* iframe */
+
+iframe {
+    border: 1px solid var(--bs-border-color) !important;
+}
+
+/* News posts */
+
+.post-content h2 {
+    margin-top: 2.75rem;
+}
+
+.post-content ul, .post-content p {
+    margin-bottom: 1.75rem;
+}
+
+/* Autocomplete search */
+
+.awesomplete [hidden] {
+    display: none;
+}
+
+.awesomplete .visually-hidden {
+    position: absolute;
+    clip: rect(0, 0, 0, 0);
+}
+
+.awesomplete {
+    display: block;
+    position: relative;
+}
+
+.awesomplete>input {
+    display: block;
+}
+
+.awesomplete>ul {
+    position: absolute;
+    left: 0;
+    z-index: 1;
+    min-width: 100%;
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0;
+    margin: 0.2em 0 0;
+    color: var(--bs-body-color);
+    background-color: var(--bs-body-bg);
+    border: var(--bs-border-width) solid var(--bs-border-color);
+    border-radius: var(--bs-border-radius);
+    box-shadow: 0.05em 0.2em 0.6em rgba(0, 0, 0, 0.2);
+    text-shadow: none;
+}
+
+.awesomplete>ul:empty {
+    display: none;
+}
+
+@supports (transform: scale(0)) {
+    .awesomplete>ul {
+        transition: 0.3s cubic-bezier(0.4, 0.2, 0.5, 1.4);
+    }
+
+    .awesomplete>ul[hidden],
+    .awesomplete>ul:empty {
+        opacity: 0;
+        transform: scale(0);
+        display: block;
+        visibility: hidden;
+        transition-timing-function: ease;
+    }
+}
+
+.awesomplete>ul>li {
+    position: relative;
+    padding: 0.7em 1em;
+    cursor: pointer;
+}
+
+.awesomplete>ul>li:hover {
+    background: hsl(200, 40%, 80%);
+    color: black;
+}
+
+.awesomplete>ul>li[aria-selected='true'] {
+    background: hsl(205, 40%, 40%);
+    color: white;
+}
+
+.awesomplete mark {
+    background: hsl(65, 100%, 50%);
+}
+
+.awesomplete li:hover mark {
+    background: hsl(68, 100%, 41%);
+}
+
+.awesomplete li[aria-selected='true'] mark {
+    background: hsl(86, 100%, 21%);
+    color: inherit;
+}
+
+/* File types */
+
+a[href$=".doc"]::after,
+a[href$=".docx"]::after,
+a[href$=".ppt"]::after,
+a[href$=".pptx"]::after,
+a[href$=".xls"]::after,
+a[href$=".xlsx"]::after,
+a[href$=".pdf"]::after,
+a[href$=".mp3"]::after,
+a[href$=".mp4"]::after,
+a[href$=".avi"]::after,
+a[href$=".mpg"]::after,
+a[href$=".mpeg"]::after,
+a[href$=".mov"]::after,
+a[href$=".wmv"]::after,
+a[href$=".mkv"]::after,
+a[href$=".jpg"]::after,
+a[href$=".jpeg"]::after,
+a[href$=".png"]::after,
+a[href$=".gif"]::after {
+    content: "";
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    margin-left: 0.5rem;
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
+a[href$=".doc"]::after,
+a[href$=".docx"]::after {
+    background-image: url(/assets/font-awesome/svgs/solid/file-word.svg);
+}
+
+a[href$=".ppt"]::after,
+a[href$=".pptx"]::after {
+    background-image: url(/assets/font-awesome/svgs/solid/file-powerpoint.svg);
+}
+
+a[href$=".xls"]::after,
+a[href$=".xlsx"]::after {
+    background-image: url(/assets/font-awesome/svgs/solid/file-excel.svg);
+}
+
+a[href$=".pdf"]::after {
+    background-image: url(/assets/font-awesome/svgs/solid/file-pdf.svg);
+}
+
+a[href$=".mp3"]::after {
+    background-image: url(/assets/font-awesome/svgs/solid/file-audio.svg);
+}
+
+a[href$=".mp4"]::after {
+    background-image: url(/assets/font-awesome/svgs/solid/file-video.svg);
+}
+
+.fa-bluesky {
+    color: #96abee !important;
+}
+
+.fa-mastodon {
+    color: #d5bfff !important;
+}
+
+.fa-book-open {
+    color: #c3ebfa !important;
+}
+
+.fa-book-open-reader {
+    color: #c3ebfa !important;
+}
+
+.fa-check {
+    color: #e7f434 !important;
+}
+
+.fa-circle-exclamation {
+    color: #ffbc78 !important;
+}
+
+.fa-circle-plus,
+.fa-toggle-on {
+    color: var(--bs-success) !important;
+}
+
+.fa-user-plus {
+    color: var(--bs-success) !important;
+}
+
+.fa-circle-dot {
+    color: #f3bf90 !important;
+}
+
+.fa-circle-down {
+    color: #e41d3d !important;
+}
+
+.fa-circle-up {
+    color: #21c834 !important;
+}
+
+.fa-comments {
+    color: #c5c5f3 !important;
+}
+
+.fa-dolly {
+    color: #f5fbc1 !important;
+}
+
+.fa-download {
+    color: #c3ebfa;
+}
+
+.fa-file-contract {
+    color: #fee685 !important;
+}
+
+.fa-file-pdf {
+    color: #f8b9c5 !important;
+}
+
+.fa-filter-circle-xmark {
+    color: #f8b9c5 !important;
+}
+
+.fa-box-archive {
+    color: #f8b9c5 !important;
+}
+
+.fa-fire {
+    color: #ffbc78 !important;
+}
+
+.fa-screwdriver-wrench {
+    color: #ffbc78;
+}
+
+.fa-highlighter {
+    color: #e7f434 !important;
+}
+
+.fa-plug-circle-bolt {
+    color: #fff5c2 !important;
+}
+
+.fa-puzzle-piece {
+    color: #98d035 !important;
+}
+
+.fa-rotate {
+    color: #c5ee93 !important;
+}
+
+.fa-share-from-square {
+    color: #f8b9c5 !important;
+}
+
+/* Icons — dark mode (vibrant pastels on dark bg) */
+
+.fa-github {
+    color: #96abee !important;
+}
+
+.fa-discord {
+    color: #96abee !important;
+}
+
+.fa-linkedin,
+.fa-linkedin-in {
+    color: #c3ebfa !important;
+}
+
+.fa-x-twitter {
+    color: #e4e4e4 !important;
+}
+
+.fa-youtube {
+    color: #fd8ba0 !important;
+}
+
+.fa-arrows-rotate {
+    color: #c5ee93 !important;
+}
+
+.fa-compact-disc {
+    color: #c5ee93 !important;
+}
+
+.fa-arrow-right-to-bracket {
+    color: var(--bs-success) !important;
+}
+
+.fa-arrow-right-arrow-left {
+    color: #face00 !important;
+}
+
+.fa-arrow-pointer {
+    color: #d5bfff;
+}
+
+.fa-asterisk {
+    color: #face00;
+}
+
+.fa-bars-progress {
+    color: #ffbc78;
+}
+
+.fa-bell {
+    color: #29e1cb !important;
+}
+
+.fa-bell-concierge {
+    color: #dec69a !important;
+}
+
+.fa-life-ring {
+    color: #dec69a !important;
+}
+
+.fa-bolt {
+    color: #face00 !important;
+}
+
+.fa-brain {
+    color: #fdb8ae !important;
+}
+
+.fa-broom {
+    color: #face00 !important;
+}
+
+.fa-bug {
+    color: #fbbaa7;
+}
+
+.fa-building {
+    color: #b7f5bd !important;
+}
+
+.fa-binoculars {
+    color: #7de8d0 !important;
+}
+
+.fa-bullhorn {
+    color: #96abee !important;
+}
+
+.fa-calendar {
+    color: #a8f2ff !important;
+}
+
+.fa-certificate {
+    color: #ffbe2e !important;
+}
+
+.fa-check-to-slot {
+    color: #ffb4cf !important;
+}
+
+.fa-circle-check {
+    color: var(--bs-success) !important;
+}
+
+.fa-circle-xmark {
+    color: #e41d3d !important;
+}
+
+.fa-circle-nodes {
+    color: #c3ebfa;
+}
+
+.fa-circle-notch {
+    color: #e6e6e6 !important;
+}
+
+.fa-circle-question {
+    color: #97d4ea;
+}
+
+a .fa-circle-question,
+a:hover .fa-circle-question,
+a .fa-circle-info,
+a:hover .fa-circle-info {
+    color: inherit !important;
+}
+
+td a .fa-circle-question,
+td a:hover .fa-circle-question,
+td a .fa-circle-info,
+td a:hover .fa-circle-info {
+    color: var(--bs-body-color) !important;
+}
+
+.fa-triangle-exclamation {
+    color: #f4a0a0;
+}
+
+.fa-circle-info {
+    color: #b8d293 !important;
+}
+
+.fa-code {
+    color: #bbc8f5 !important;
+}
+
+.fa-comment {
+    color: #c5c5f3 !important;
+}
+
+.fa-crown {
+    color: #ffe396 !important;
+}
+
+.fa-dashboard {
+    color: #ffbc78;
+}
+
+.fa-diagram-project {
+    color: #7efbe1 !important;
+}
+
+.fa-envelope {
+    color: #c3ebfa;
+}
+
+.fa-envelope-open-text {
+    color: #7efbe1 !important;
+}
+
+.fa-eye {
+    color: #7de8d0;
+}
+
+.fa-face-sad-tear {
+    color: #face00;
+}
+
+.fa-dove,
+.fa-face-grin-hearts,
+.fa-face-smile {
+    color: #fffb00;
+}
+
+.fa-file {
+    color: #a8f2ff;
+}
+
+.fa-file-lines {
+    color: #a8f2ff;
+}
+
+.fa-filter {
+    color: #cbc4f2;
+}
+
+.fa-flag {
+    color: #f45d79;
+}
+
+.fa-gauge {
+    color: #ffbc78;
+}
+
+.fa-gauge-simple {
+    color: #ffbc78;
+}
+
+.fa-gauge-high {
+    color: #ffbc78;
+}
+
+.fa-chart-line {
+    color: #ffbc78;
+}
+
+.fa-gear,
+.fa-gears {
+    color: #a1d3ff;
+}
+
+.fa-network-wired {
+    color: #a1d3ff;
+}
+
+.fa-graduation-cap {
+    color: #c7efe2;
+}
+
+.fa-hand, .fa-hands, .fa-hands-clapping,
+.fa-handshake,
+.fa-handshake-simple, .fa-handshake-angle,
+.fa-hand-peace,
+.fa-hand-point-up, .fa-hand-point-down,
+.fa-hand-point-right, .fa-hand-point-left {
+    color: #face00;
+}
+
+.fa-hand-pointer {
+    color: #d5bfff;
+}
+
+.fa-heart {
+    color: #ff8d7b;
+}
+
+.fa-heart-crack {
+    color: #ff8d7b;
+}
+
+.fa-house {
+    color: #f4b2ff;
+}
+
+.fa-key {
+    color: #fee685;
+}
+
+.fa-laptop {
+    color: #9bd4cf;
+}
+
+.fa-landmark {
+    color: #b0d0f0 !important;
+}
+
+.fa-lightbulb,
+.fa-message {
+    color: #ffe396 !important;
+}
+
+.fa-link {
+    color: #7efbe1;
+}
+
+.fa-list-check {
+    color: #c3ebfa;
+}
+
+.fa-lock {
+    color: #ff8d7b;
+}
+
+.fa-magnifying-glass,
+.fa-magnifying-glass-chart {
+    color: #ffe396;
+}
+
+.fa-map {
+    color: #fdb8ae;
+}
+
+.fa-newspaper {
+    color: #b0d0f0;
+}
+
+.fa-paper-plane {
+    color: #c3ebfa;
+}
+
+.fa-percent {
+    color: #a8f2ff;
+}
+
+.fa-ranking-star {
+    color: #83fcd4;
+}
+
+.fa-rectangle-list {
+    color: #f8b9c5;
+}
+
+.fa-folder-tree,
+.fa-sitemap {
+    color: #ffbc78 !important;
+}
+
+.fa-right-from-bracket {
+    color: var(--bs-success) !important;
+}
+
+.fa-robot {
+    color: #e7f434 !important;
+}
+
+.fa-rocket {
+    color: #d0c3e9;
+}
+
+.fa-rss {
+    color: #ffbc78;
+}
+
+.fa-satellite-dish {
+    color: #c3ebfa !important;
+}
+
+.fa-scale-balanced {
+    color: #e6c74c;
+}
+
+.fa-scroll {
+    color: #fee685 !important;
+}
+
+.fa-seedling {
+    color: #c5ee93;
+}
+
+.fa-server {
+    color: #fbbaa7;
+}
+
+.fa-share-nodes {
+    color: #ffb4cf;
+}
+
+.fa-shield-halved {
+    color: #ff8d7b;
+}
+
+.fa-spray-can-sparkles {
+    color: #d0b4f5;
+}
+
+.fa-square-check {
+    color: #c3ebfa;
+}
+
+.fa-star {
+    color: #e6c74c;
+}
+
+.fa-table {
+    color: #7efbe1;
+}
+
+.fa-table-columns {
+    color: #7efbe1;
+}
+
+.fa-database {
+    color: #a8f5d5;
+}
+
+.fa-timeline {
+    color: #ffb4cf;
+}
+
+.fa-universal-access {
+    color: #a8f2ff;
+}
+
+.fa-arrow-right,
+.fa-arrow-right-long {
+    color: #c3ebfa;
+}
+
+.fa-copy {
+    color: #7efbe1;
+}
+
+.fa-face-frown {
+    color: #fbbaa7;
+}
+
+.fa-print {
+    color: #d0c3e9;
+}
+
+.fa-up-right-from-square {
+    color: #7efbe1;
+}
+
+a .fa-up-right-from-square {
+    margin-left: 0.3em;
+}
+
+.fa-user-astronaut {
+    color: #f8b9c5;
+}
+
+.fa-user-group {
+    color: #96abee;
+}
+
+.fa-user-shield {
+    color: #f3bf90;
+}
+
+.fa-wand-magic-sparkles {
+    color: #ffe396;
+}
+
+.fa-wave-square {
+    color: #96abee !important;
+}
+
+.fa-window-maximize {
+    color: #ffcdd5;
+}
+
+.fa-building-columns {
+    color: #b0d0f0 !important;
+}
+
+.fa-chart-simple {
+    color: #ffbc78 !important;
+}
+
+.fa-check-circle {
+    color: var(--bs-success) !important;
+}
+
+.fa-circle-play {
+    color: #7de8d0 !important;
+}
+
+.fa-concierge-bell {
+    color: #dec69a !important;
+}
+
+.fa-photo-film {
+    color: #d5bfff !important;
+}
+
+.fa-stop-circle {
+    color: #ffbc78 !important;
+}
+
+/* Icons — light mode overrides (WCAG 2.2 AA compliant, min 4.5:1 on #fff) */
+
+[data-bs-theme=light] .fa-arrow-right-to-bracket,
+[data-bs-theme=light] .fa-arrows-rotate,
+[data-bs-theme=light] .fa-compact-disc,
+[data-bs-theme=light] .fa-building,
+[data-bs-theme=light] .fa-check-circle,
+[data-bs-theme=light] .fa-circle-check,
+[data-bs-theme=light] .fa-circle-info,
+[data-bs-theme=light] .fa-circle-plus,
+[data-bs-theme=light] .fa-puzzle-piece,
+[data-bs-theme=light] .fa-right-from-bracket,
+[data-bs-theme=light] .fa-rotate,
+[data-bs-theme=light] .fa-seedling,
+[data-bs-theme=light] .fa-toggle-on {
+    /* → #2d7a3a = 5.31:1 ✓ */
+    color: #2d7a3a !important;
+}
+
+[data-bs-theme=light] .fa-bell,
+[data-bs-theme=light] .fa-copy,
+[data-bs-theme=light] .fa-diagram-project,
+[data-bs-theme=light] .fa-envelope-open-text,
+[data-bs-theme=light] .fa-graduation-cap,
+[data-bs-theme=light] .fa-link,
+[data-bs-theme=light] .fa-ranking-star,
+[data-bs-theme=light] .fa-table,
+[data-bs-theme=light] .fa-table-columns,
+[data-bs-theme=light] .fa-up-right-from-square {
+    /* → #0d7a6e = 5.22:1 ✓ */
+    color: #0d7a6e !important;
+}
+
+[data-bs-theme=light] .fa-bell-concierge,
+[data-bs-theme=light] .fa-brain,
+[data-bs-theme=light] .fa-bug,
+[data-bs-theme=light] .fa-concierge-bell,
+[data-bs-theme=light] .fa-face-frown,
+[data-bs-theme=light] .fa-life-ring,
+[data-bs-theme=light] .fa-map,
+[data-bs-theme=light] .fa-server {
+    /* → #8a5e2d = 5.65:1 ✓ */
+    color: #8a5e2d !important;
+}
+
+[data-bs-theme=light] .fa-bolt,
+[data-bs-theme=light] .fa-broom,
+[data-bs-theme=light] .fa-certificate,
+[data-bs-theme=light] .fa-check,
+[data-bs-theme=light] .fa-crown,
+[data-bs-theme=light] .fa-dolly,
+[data-bs-theme=light] .fa-dove,
+[data-bs-theme=light] .fa-face-grin-hearts,
+[data-bs-theme=light] .fa-face-sad-tear,
+[data-bs-theme=light] .fa-face-smile,
+[data-bs-theme=light] .fa-file-contract,
+[data-bs-theme=light] .fa-hand, [data-bs-theme=light] .fa-hands,
+[data-bs-theme=light] .fa-key,
+[data-bs-theme=light] .fa-hands-clapping,
+[data-bs-theme=light] .fa-handshake,
+[data-bs-theme=light] .fa-handshake-simple,
+[data-bs-theme=light] .fa-handshake-angle,
+[data-bs-theme=light] .fa-hand-peace,
+[data-bs-theme=light] .fa-hand-point-up,
+[data-bs-theme=light] .fa-hand-point-down,
+[data-bs-theme=light] .fa-hand-point-right,
+[data-bs-theme=light] .fa-hand-point-left,
+[data-bs-theme=light] .fa-highlighter,
+[data-bs-theme=light] .fa-lightbulb,
+[data-bs-theme=light] .fa-message,
+[data-bs-theme=light] .fa-magnifying-glass,
+[data-bs-theme=light] .fa-magnifying-glass-chart,
+[data-bs-theme=light] .fa-plug-circle-bolt,
+[data-bs-theme=light] .fa-robot,
+[data-bs-theme=light] .fa-scale-balanced,
+[data-bs-theme=light] .fa-scroll,
+[data-bs-theme=light] .fa-star,
+[data-bs-theme=light] .fa-stop-circle,
+[data-bs-theme=light] .fa-wand-magic-sparkles {
+    /* → #8a6500 = 5.33:1 ✓ */
+    color: #8a6500 !important;
+}
+
+[data-bs-theme=light] .fa-arrow-right-arrow-left,
+[data-bs-theme=light] .fa-asterisk {
+    /* → #8a6500 on #fff = 5.33:1 ✓ */
+    color: #8a6500 !important;
+}
+
+[data-bs-theme=light] .fa-bars-progress,
+[data-bs-theme=light] .fa-chart-simple,
+[data-bs-theme=light] .fa-chart-line,
+[data-bs-theme=light] .fa-circle-exclamation,
+[data-bs-theme=light] .fa-dashboard,
+[data-bs-theme=light] .fa-fire,
+[data-bs-theme=light] .fa-folder-tree,
+[data-bs-theme=light] .fa-gauge,
+[data-bs-theme=light] .fa-gauge-simple,
+[data-bs-theme=light] .fa-gauge-high,
+[data-bs-theme=light] .fa-rss,
+[data-bs-theme=light] .fa-screwdriver-wrench,
+[data-bs-theme=light] .fa-sitemap {
+    /* → #8a4f00 = 6.56:1 ✓ */
+    color: #8a4f00 !important;
+}
+
+[data-bs-theme=light] .btn.btn-outline-primary .fa-sitemap {
+    color: #8a4f00 !important;
+}
+
+[data-bs-theme=light] .btn.btn-outline-primary:hover .fa-sitemap,
+[data-bs-theme=light] .btn.btn-outline-primary:focus .fa-sitemap {
+    color: inherit !important;
+}
+
+[data-bs-theme=light] .fa-arrow-right,
+[data-bs-theme=light] .fa-arrow-right-long,
+[data-bs-theme=light] .fa-book-open,
+[data-bs-theme=light] .fa-book-open-reader,
+[data-bs-theme=light] .fa-calendar,
+[data-bs-theme=light] .fa-circle-nodes,
+[data-bs-theme=light] .fa-download,
+[data-bs-theme=light] .fa-envelope,
+[data-bs-theme=light] .fa-file,
+[data-bs-theme=light] .fa-file-lines,
+[data-bs-theme=light] .fa-linkedin,
+[data-bs-theme=light] .fa-linkedin-in,
+[data-bs-theme=light] .fa-x-twitter,
+[data-bs-theme=light] .fa-paper-plane,
+[data-bs-theme=light] .fa-percent,
+[data-bs-theme=light] .fa-list-check,
+[data-bs-theme=light] .fa-satellite-dish,
+[data-bs-theme=light] .fa-square-check,
+[data-bs-theme=light] .fa-universal-access {
+    /* → #1a6fa0 = 5.49:1 ✓ */
+    color: #1a6fa0 !important;
+}
+
+[data-bs-theme=light] .fa-binoculars,
+[data-bs-theme=light] .fa-circle-play,
+[data-bs-theme=light] .fa-eye {
+    /* → #1a7a6a = 5.21:1 ✓ */
+    color: #1a7a6a !important;
+}
+
+[data-bs-theme=light] .fa-bluesky,
+[data-bs-theme=light] .fa-code,
+[data-bs-theme=light] .fa-bullhorn,
+[data-bs-theme=light] .fa-discord,
+[data-bs-theme=light] .fa-github,
+[data-bs-theme=light] .fa-user-group,
+[data-bs-theme=light] .fa-wave-square {
+    /* → #4a6bb5 = 5.17:1 ✓ */
+    color: #4a6bb5 !important;
+}
+
+[data-bs-theme=light] .fa-comment,
+[data-bs-theme=light] .fa-comments,
+[data-bs-theme=light] .fa-filter,
+[data-bs-theme=light] .fa-print,
+[data-bs-theme=light] .fa-rocket {
+    /* → #5b4ea0 = 6.90:1 ✓ */
+    color: #5b4ea0 !important;
+}
+
+[data-bs-theme=light] .feedback .fa-rocket {
+    color: inherit !important;
+}
+
+[data-bs-theme=light] .fa-circle-notch {
+    /* → #5a5a5a = 6.90:1 ✓ */
+    color: #5a5a5a !important;
+}
+
+[data-bs-theme=light] .fa-circle-question {
+    /* → #1a6fa0 = 5.49:1 ✓ */
+    color: #1a6fa0;
+}
+
+[data-bs-theme=light] a .fa-circle-question,
+[data-bs-theme=light] a:hover .fa-circle-question,
+[data-bs-theme=light] a .fa-circle-info,
+[data-bs-theme=light] a:hover .fa-circle-info {
+    color: inherit !important;
+}
+
+[data-bs-theme=light] .fa-triangle-exclamation {
+    /* → #b03030 = 5.62:1 ✓ */
+    color: #b03030;
+}
+
+[data-bs-theme=light] .fa-box-archive,
+[data-bs-theme=light] .fa-file-pdf,
+[data-bs-theme=light] .fa-filter-circle-xmark,
+[data-bs-theme=light] .fa-rectangle-list,
+[data-bs-theme=light] .fa-share-from-square,
+[data-bs-theme=light] .fa-user-astronaut {
+    /* → #b5476a = 5.15:1 ✓ */
+    color: #b5476a !important;
+}
+
+[data-bs-theme=light] .fa-circle-down,
+[data-bs-theme=light] .fa-circle-xmark,
+[data-bs-theme=light] .fa-flag {
+    /* → #b52040 = 6.47:1 ✓ */
+    color: #b52040 !important;
+}
+
+[data-bs-theme=light] .fa-circle-up {
+    /* → #1a7a2a = 5.10:1 ✓ */
+    color: #1a7a2a !important;
+}
+
+[data-bs-theme=light] .fa-building-columns,
+[data-bs-theme=light] .fa-circle-dot,
+[data-bs-theme=light] .fa-gear,
+[data-bs-theme=light] .fa-gears,
+[data-bs-theme=light] .fa-network-wired,
+[data-bs-theme=light] .fa-newspaper {
+    /* → #1a5e9e = 6.69:1 ✓ */
+    color: #1a5e9e !important;
+}
+
+[data-bs-theme=light] .fa-heart,
+[data-bs-theme=light] .fa-heart-crack,
+[data-bs-theme=light] .fa-lock,
+[data-bs-theme=light] .fa-shield-halved {
+    /* → #c0392b = 5.44:1 ✓ */
+    color: #c0392b !important;
+}
+
+[data-bs-theme=light] .fa-house {
+    /* → #7a2ea0 = 7.70:1 ✓ */
+    color: #7a2ea0 !important;
+}
+
+[data-bs-theme=light] .fa-laptop {
+    /* → #1a6e6a = 6.03:1 ✓ */
+    color: #1a6e6a !important;
+}
+
+[data-bs-theme=light] .fa-landmark {
+    /* → #1a5e9e = 6.69:1 ✓ */
+    color: #1a5e9e !important;
+}
+
+[data-bs-theme=light] .fa-share-nodes,
+[data-bs-theme=light] .fa-check-to-slot,
+[data-bs-theme=light] .fa-timeline {
+    /* → #9e2060 = 7.42:1 ✓ */
+    color: #9e2060 !important;
+}
+
+[data-bs-theme=light] .fa-database {
+    /* → #0d6b52 = 7.3:1 ✓ */
+    color: #0d6b52 !important;
+}
+
+[data-bs-theme=light] .fa-arrow-pointer,
+[data-bs-theme=light] .fa-hand-pointer,
+[data-bs-theme=light] .fa-mastodon,
+[data-bs-theme=light] .fa-photo-film,
+[data-bs-theme=light] .fa-spray-can-sparkles {
+    /* → #6b3fa0 = 7.38:1 ✓ */
+    color: #6b3fa0 !important;
+}
+
+[data-bs-theme=light] .fa-user-shield {
+    /* → #8a4e00 = 6.62:1 ✓ */
+    color: #8a4e00 !important;
+}
+
+[data-bs-theme=light] .fa-window-maximize {
+    /* → #a03050 = 6.92:1 ✓ */
+    color: #a03050 !important;
+}
+
+[data-bs-theme=light] .fa-youtube {
+    /* → #c0392b = 5.44:1 ✓ */
+    color: #c0392b !important;
+}
+
+/* Status card icons — must come last to beat FA light mode overrides */
+[data-bs-theme=light] .card.text-bg-success,
+[data-bs-theme=light] .card.text-bg-success a,
+[data-bs-theme=light] .card.text-bg-success a:link,
+[data-bs-theme=light] .card.text-bg-success a:visited,
+[data-bs-theme=light] .card.text-bg-success a:hover,
+[data-bs-theme=light] .card.text-bg-success a:focus,
+[data-bs-theme=light] .card.text-bg-success i,
+[data-bs-theme=light] .card.text-bg-success svg,
+[data-bs-theme=light] .card.text-bg-success a i,
+[data-bs-theme=light] .card.text-bg-success a svg,
+[data-bs-theme=light] .card.text-bg-warning,
+[data-bs-theme=light] .card.text-bg-warning a,
+[data-bs-theme=light] .card.text-bg-warning a:link,
+[data-bs-theme=light] .card.text-bg-warning a:visited,
+[data-bs-theme=light] .card.text-bg-warning a:hover,
+[data-bs-theme=light] .card.text-bg-warning a:focus,
+[data-bs-theme=light] .card.text-bg-warning i,
+[data-bs-theme=light] .card.text-bg-warning svg,
+[data-bs-theme=light] .card.text-bg-warning a i,
+[data-bs-theme=light] .card.text-bg-warning a svg {
+    color: #13171f !important;
+    fill: #13171f !important;
+}
+
+[data-bs-theme=light] .card.text-bg-danger,
+[data-bs-theme=light] .card.text-bg-danger a,
+[data-bs-theme=light] .card.text-bg-danger a:link,
+[data-bs-theme=light] .card.text-bg-danger a:visited,
+[data-bs-theme=light] .card.text-bg-danger a:hover,
+[data-bs-theme=light] .card.text-bg-danger a:focus,
+[data-bs-theme=light] .card.text-bg-danger i,
+[data-bs-theme=light] .card.text-bg-danger svg,
+[data-bs-theme=light] .card.text-bg-danger a i,
+[data-bs-theme=light] .card.text-bg-danger a svg {
+    color: #ffffff !important;
+    fill: #ffffff !important;
+}
+
+/* text-bg-dark card icons match white text */
+.card.text-bg-dark a,
+.card.text-bg-dark a:link,
+.card.text-bg-dark a:visited,
+.card.text-bg-dark a:hover,
+.card.text-bg-dark a:focus,
+.card.text-bg-dark i,
+.card.text-bg-dark svg,
+.card.text-bg-dark a i,
+.card.text-bg-dark a svg {
+    color: #ffffff !important;
+    fill: #ffffff !important;
+}
+
+/* Question mark help icons inherit text color via href targeting */
+a[href*="docs.scangov.org"] svg,
+a[href*="docs.scangov.org"] i {
+    color: inherit !important;
+    fill: currentColor !important;
+}
+
+/* Font Awesome size utilities */
+.fa-2xs {
+    font-size: 0.625em;
+}
+
+.fa-xs {
+    font-size: 0.75em;
+}
+
+.fa-sm {
+    font-size: 0.875em;
+}
+
+.fa-lg {
+    font-size: 1.25em;
+}
+
+.fa-xl {
+    font-size: 1.5em;
+}
+
+.fa-2xl {
+    font-size: 2em;
+}
+
+.fa-1x {
+    font-size: 1em;
+}
+
+.fa-2x {
+    font-size: 2em;
+}
+
+.fa-3x {
+    font-size: 3em;
+}
+
+.fa-4x {
+    font-size: 4em;
+}
+
+.fa-5x {
+    font-size: 5em;
+}
+
+.fa-6x {
+    font-size: 6em;
+}
+
+.fa-7x {
+    font-size: 7em;
+}
+
+.fa-8x {
+    font-size: 8em;
+}
+
+.fa-9x {
+    font-size: 9em;
+}
+
+.fa-10x {
+    font-size: 10em;
+}
+
+select.js-subfilters {
+    width: 100%;
+    border-radius: 0;
+}
+
+select.js-subfilters:hover {
+    --bs-body-bg: var(--bs-primary);
+    background-color: var(--bs-primary) !important;
+    color: var(--bs-primary-text) !important;
+    border-color: var(--bs-primary) !important;
+    box-shadow: var(--bs-shadow) !important;
+    border-radius: 0 !important;
+}
+
+thead th {
+    font-family: var(--bs-font-monospace);
+}
+
+/* Table header links */
+th a {
+    color: var(--bs-link-color);
+    text-decoration: none;
+}
+
+th a:hover {
+    color: var(--bs-link-hover-color);
+    text-decoration: underline;
+}
+
+th a i, th a svg,
+th a:link i, th a:link svg,
+th a:visited i, th a:visited svg,
+th a:hover i, th a:hover svg,
+th a:focus i, th a:focus svg {
+    color: var(--bs-body-color) !important;
+    fill: var(--bs-body-color) !important;
+    text-decoration: none;
+}
+
+/* Docs */
+#post h2 {
+    margin-top: 2.5rem;
+}
+
+#post h3 {
+    margin-top: 2rem;
+    font-size: 1.1rem;
+}
+
+#post .alert h2 {
+    margin-top: 2rem;
+}
+
+#post .alert h3 {
+    margin-top: 2rem;
+    font-size: inherit;
+}
+
+.js-sidenav {
+    top: 1rem;
+}
+
+.js-sidenav a:hover {
+    color: var(--bs-link-color) !important;
+}
+
+.scan-notice {
+    position: fixed;
+    bottom: 1rem;
+    left: 1rem;
+    right: 1rem;
+    z-index: 1050;
+    margin: 0;
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.scan-notice .btn-close {
+    flex-shrink: 0;
+    margin-left: auto;
+}
+
+@media (min-width: 768px) {
+    .scan-notice {
+        width: 75%;
+        left: 50%;
+        right: auto;
+        transform: translateX(-50%);
+    }
+}
+
+/* Actions list: separate boxes — restore left border + full radius on every item */
+.actions.list-group .list-group-item {
+    padding: 0;
+    border-radius: var(--bs-list-group-border-radius) !important;
+}
+
+.actions .list-group-item+.list-group-item {
+    border-left-width: var(--bs-list-group-border-width);
+}
+
+/* Card links: underline on hover only */
+.card a:not(.btn):not(.stretched-link) {
+    text-decoration: none;
+}
+
+.card a:not(.btn):not(.stretched-link):hover {
+    text-decoration: underline;
+}
+
+.card .stretched-link {
+    text-decoration: none;
+}
+
+.card .stretched-link:hover {
+    text-decoration: underline;
+}
+
+/* Card heading links: body color by default, link color on hover */
+.card h1 a, .card h2 a, .card h3 a,
+.card h4 a, .card h5 a, .card h6 a,
+.card .h1 a, .card .h2 a, .card .h3 a,
+.card .h4 a, .card .h5 a, .card .h6 a {
+    color: var(--bs-body-color);
+    text-decoration: none;
+}
+
+.card h1 a:hover, .card h2 a:hover, .card h3 a:hover,
+.card h4 a:hover, .card h5 a:hover, .card h6 a:hover,
+.card .h1 a:hover, .card .h2 a:hover, .card .h3 a:hover,
+.card .h4 a:hover, .card .h5 a:hover, .card .h6 a:hover {
+    color: var(--bs-link-color);
+    text-decoration: underline;
+}
+
+/* Search no-results icon */
+.fa-signs-post {
+    color: #ffbe2e;
+}
+
+[data-bs-theme=light] .fa-signs-post {
+    color: #8a6500 !important;
+}
+
+/* Lunr search results */
+#lunrsearchresults {
+    padding-top: 0.2rem;
+}
+
+.lunrsearchresult {
+    padding-bottom: 1rem;
+}
+
+.lunrsearchresult .title {
+    color: var(--bs-body-color);
+}
+
+.lunrsearchresult .url {
+    color: var(--bs-body-color);
+}
+
+.lunrsearchresult a {
+    display: block;
+    color: var(--bs-body-color);
+}
+
+.lunrsearchresult a:hover,
+.lunrsearchresult a:focus {
+    text-decoration: none;
+}
+
+.lunrsearchresult a:hover .title {
+    text-decoration: underline;
+}
+
+/* SVG maps */
+svg#report-map,
+svg#map {
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+}
+
+svg#report-map {
+    width: 85%;
+    max-width: 85%;
+}
+
+svg#report-map a,
+svg#map a {
+    transition: 0.5s filter;
+}
+
+svg#report-map a:hover,
+svg#map a:hover {
+    filter: brightness(1.3);
+}
+
+.report-map-borders,
+.borders {
+    stroke: var(--bs-body-bg);
+    stroke-width: 1px;
+}
+
+#report-legend>span,
+#legend>span {
+    margin-left: 1rem;
+}
+
+/* Dataset preview */
+.dataset-preview {
+    max-height: 400px;
+    overflow-y: scroll;
+}
+
+.dataset-preview--code {
+    overflow-x: auto;
+}
+
+/* Timeline icon column min-width */
+.timeline .col-auto {
+    min-width: 4rem;
+}
+
+/* Print */
+.page-break {
+    page-break-before: always;
+}
+
+@media print {
+    body {
+        font-family: "Public Sans Regular", sans-serif;
+    }
+
+    svg {
+        fill: black !important;
+    }
+
+    div.card {
+        border: 1px solid black;
+        background-color: transparent;
+    }
+
+    div.card-header {
+        border-bottom: 1px solid var(--bs-border-color);
+    }
+
+    div.card-footer {
+        border-top: 1px solid var(--bs-border-color);
+    }
+
+    * {
+        color: black !important;
+    }
+
+    main#page {
+        display: none;
+    }
+}
+
+/* Issue report modal */
+.popoverstyling {
+    width: min(700px, 95vw);
+    max-width: 700px;
+    padding: 0;
+    border: none;
+    background: transparent;
+    margin: auto;
+    --bs-modal-padding: 1rem;
+    --bs-modal-bg: var(--bs-body-bg);
+    --bs-modal-color: var(--bs-body-color);
+    --bs-modal-border-color: var(--bs-border-color);
+    --bs-modal-border-width: var(--bs-border-width);
+    --bs-modal-border-radius: var(--bs-border-radius-lg);
+    --bs-modal-inner-border-radius: calc(var(--bs-border-radius-lg) - var(--bs-border-width));
+    --bs-modal-header-padding-x: 1rem;
+    --bs-modal-header-padding-y: 1rem;
+    --bs-modal-header-padding: 1rem 1rem;
+    --bs-modal-header-border-color: var(--bs-border-color);
+    --bs-modal-header-border-width: var(--bs-border-width);
+    --bs-modal-title-line-height: 1.5;
+    --bs-modal-footer-gap: 0.5rem;
+    --bs-modal-footer-border-color: var(--bs-border-color);
+    --bs-modal-footer-border-width: var(--bs-border-width);
+}
+
+body:has(dialog.popoverstyling[open]) {
+    overflow: hidden;
+}
+
+dialog.popoverstyling .modal-content {
+    max-height: 85vh;
+    overflow: hidden;
+}
+
+dialog.popoverstyling .modal-body {
+    overflow-y: auto;
+}
+
+dialog.popoverstyling .modal-header .modal-title {
+    font-size: 1rem;
+    font-family: var(--bs-font-sans-serif);
+    margin-bottom: 0;
+}
+
+dialog.popoverstyling .modal-footer .btn {
+    padding: 0.375rem 0.75rem;
+    font-family: var(--bs-font-sans-serif);
+}
+
+dialog.popoverstyling .modal-body h3,
+dialog.popoverstyling .modal-body h4 {
+    margin-top: 1.75rem;
+}
+
+dialog.popoverstyling .modal-body > h3:first-child {
+    margin-top: 0;
+}
+
+dialog.popoverstyling .modal-body table {
+    width: 100%;
+}
+
+dialog[open] {
+    animation: slide-in-up .3s cubic-bezier(.25, 0, .3, 1);
+}
+
+dialog::backdrop { }
+
+@keyframes slide-in-up {
+    0% { transform: translateY(100%); }
+}
+
+/* Dark mode — indigo-slate theme */
+[data-bs-theme=dark] {
+    --bs-body-bg: #1a1b2e;
+    --bs-body-bg-rgb: 26, 27, 46;
+    --bs-body-secondary-bg: #13141f;
+    --bs-border-color: rgba(255, 255, 255, 0.07);
+}


### PR DESCRIPTION
…nd add people/post metadata

Wires up the previously-broken critical-CSS inlining build step (was silently loading ~304KB of unpurged external CSS on every page instead of a small inlined block), fixes two CSS bugs that surfaced once it worked (relative font URLs, nav-link active padding), fixes a heading-order violation on /now-scanning/, adds title/description to people.json with unlabeled-link and missing-description fixes on /people/, and adds a News breadcrumb to post pages.