### PR TITLE
Add new feature cards, live example links, and clean up now-scanning …

### DIFF
--- a/_data/features.json
+++ b/_data/features.json
@@ -13,6 +13,9 @@
       },
       {
         "title": "Drill into any domain for details"
+      },
+      {
+        "title": "Filter and sort every domain by any indicator"
       }
     ]
   },
@@ -106,6 +109,7 @@
     "description": "Publish a public scorecard that shows your digital experience grades and builds trust.",
     "icon": "fa-star",
     "video": "8LErMmgYUDg",
+    "workExample": "https://my.scangov.com/public/key5279-1751598352407/scangov-com/report",
     "items": [
       {
         "title": "Public-facing view of your grades"
@@ -115,6 +119,9 @@
       },
       {
         "title": "Builds a culture of transparency"
+      },
+      {
+        "title": "Share directly to LinkedIn, Bluesky, Mastodon, X, or email"
       }
     ]
   },
@@ -149,6 +156,70 @@
       },
       {
         "title": "Open visibility into what's next"
+      }
+    ]
+  },
+  {
+    "title": "Single sign-on",
+    "description": "Let your team sign in with your organization's existing identity provider, so access stays centrally managed.",
+    "icon": "fa-key",
+    "items": [
+      {
+        "title": "Sign in with your organization's identity provider"
+      },
+      {
+        "title": "No separate passwords to manage"
+      },
+      {
+        "title": "Centralized access control for your team"
+      }
+    ]
+  },
+  {
+    "title": "URL management",
+    "description": "Control exactly which pages are monitored, and keep your page list in sync as your site changes.",
+    "icon": "fa-link",
+    "items": [
+      {
+        "title": "Add or remove pages from monitoring"
+      },
+      {
+        "title": "Sync automatically from your sitemap"
+      },
+      {
+        "title": "Track redirected and retired pages separately"
+      }
+    ]
+  },
+  {
+    "title": "GitHub integration",
+    "description": "Connect your GitHub repo so issues flow straight into your team's existing developer workflow.",
+    "icon": "fa-code-branch",
+    "items": [
+      {
+        "title": "Connect your GitHub repo in a few clicks"
+      },
+      {
+        "title": "Issues sync automatically, no manual copy-paste"
+      },
+      {
+        "title": "Fixes stay in your team's existing workflow"
+      }
+    ]
+  },
+  {
+    "title": "Scan management",
+    "description": "Keep your monitoring data fresh with on-demand rescans and full visibility into scan status.",
+    "icon": "fa-rotate",
+    "items": [
+      {
+        "title": "Trigger an on-demand rescan anytime"
+      },
+      {
+        "title": "See real-time scan progress and status"
+      },
+      {
+        "title": "Review scan history for every domain"
       }
     ]
   }

--- a/_includes/now_scanning_list.html
+++ b/_includes/now_scanning_list.html
@@ -3,8 +3,8 @@
     {% for item in now_scanning | head(-4) %}
       <div class="col-12 col-sm-12 col-md-3 col-lg-3 col-xl-3 d-flex align-items-stretch">
         <div class="card position-relative">
-          <div class="card-body py-5 d-flex flex-column align-items-center justify-content-center text-center">
-            <i class="fa-solid fa-arrow-pointer fa-2x mb-3" aria-hidden="true"></i>
+          <div class="card-body py-4 d-flex flex-column align-items-center justify-content-center text-center">
+            <i class="fa-solid fa-bars-progress fa-2x mb-3" aria-hidden="true"></i>
             <h3 class="h4 mb-0">
               <a href="/now-scanning/{{ item.title | slugify }}/" class="stretched-link">{{ item.title }}</a>
             </h3>
@@ -18,49 +18,11 @@
     {% for item in now_scanning %}
       <div class="col-12 col-sm-12 col-md-3 col-lg-3 col-xl-3 d-flex align-items-stretch">
         <div class="card position-relative">
-          <div class="card-body py-5 d-flex flex-column align-items-center justify-content-center text-center">
-            <i class="fa-solid fa-arrow-pointer fa-2x mb-3" aria-hidden="true"></i>
+          <div class="card-body py-4 d-flex flex-column align-items-center justify-content-center text-center">
+            <i class="fa-solid fa-bars-progress fa-2x mb-3" aria-hidden="true"></i>
             <h2 class="h4 mb-0">
               <a href="/now-scanning/{{ item.title | slugify }}/" class="stretched-link">{{ item.title }}</a>
             </h2>
-          </div>
-        </div>
-      </div>
-    {% endfor %}
-  </div>
-{% elif website %}
-  <div class="row g-3">
-    {% for item in now_scanning | exclude("title", website.title) | slice(0, 3) %}
-      <div class="col-12 col-sm-12 col-md-4 col-lg-4 col-xl-4 d-flex align-items-stretch">
-        <div class="card">
-          <div class="card-body p-3">
-            <img
-              loading="lazy"
-              src="/../public/assets/img/pages/{{ item.img }}"
-              class="mt-2 mb-3 img-fluid border rounded shadow"
-              alt="{{ item.title }}">
-            <h3 class="h5">
-              <a href="/now-scanning/{{ item.title | slugify }}" class="stretched-link nav-link">{{ item.title }}</a>
-            </h3>
-          </div>
-        </div>
-      </div>
-    {% endfor %}
-  </div>
-{% else %}
-  <div class="row g-3">
-    {% for item in now_scanning %}
-      <div class="col-12 col-sm-12 col-md-4 col-lg-4 col-xl-4 d-flex align-items-stretch">
-        <div class="card">
-          <div class="card-body p-3">
-            <img
-              loading="lazy"
-              src="/../public/assets/img/pages/{{ item.img }}"
-              class="mt-2 mb-3 img-fluid border rounded shadow"
-              alt="{{ item.title }}">
-            <h3 class="h5">
-              <a href="/now-scanning/{{ item.title | slugify }}" class="stretched-link nav-link">{{ item.title }}</a>
-            </h3>
           </div>
         </div>
       </div>

--- a/content/feature.html
+++ b/content/feature.html
@@ -32,6 +32,11 @@ eleventyComputed:
           <li class="mb-2"><i class="fa-solid fa-circle-check me-2" aria-hidden="true"></i>{{ item.title }}</li>
         {% endfor %}
       </ul>
+      {% if feature.workExample %}
+      <a href="{{ feature.workExample }}" class="btn btn-outline-primary mt-4" target="_blank" rel="noopener">
+        <i class="fa-solid fa-wand-sparkles me-2" aria-hidden="true"></i>{{ feature.title }} example
+      </a>
+      {% endif %}
     </div>
     {% endif %}
     {% if feature.video %}

--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -59,9 +59,9 @@
     --bs-primary-text: #13171f;
     --bs-body-color: #fff;
     --bs-body-color-rgb: 255, 255, 255;
-    --bs-body-bg: #13171f;
-    --bs-body-bg-rgb: 19, 23, 31;
-    --bs-body-secondary-bg: #0f1218;
+    --bs-body-bg: #1a1b2e;
+    --bs-body-bg-rgb: 26, 27, 46;
+    --bs-body-secondary-bg: #13141f;
     --bs-link-color: #4FB8F0;
     --bs-link-color-rgb: 79, 184, 240;
     --bs-link-hover-color: var(--bs-link-color);
@@ -87,7 +87,7 @@
     --bs-btn-hover-color: var(--bs-primary-text);
     --bs-nav-link-color: var(--bs-body-color);
     --bs-nav-link-hover-color: var(--bs-link-color);
-    --bs-border-color: #252f3e;
+    --bs-border-color: rgba(255, 255, 255, 0.07);
     --bs-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
     --bs-card-shadow: var(--bs-shadow);
     --bs-box-shadow: var(--bs-shadow);
@@ -687,6 +687,15 @@ button.btn-primary-outline:focus {
 
 .btn.btn-outline-primary:hover .fa-sitemap,
 .btn.btn-outline-primary:focus .fa-sitemap {
+    color: inherit !important;
+}
+
+.btn.btn-outline-primary .fa-wand-sparkles {
+    color: #ffe396 !important;
+}
+
+.btn.btn-outline-primary:hover .fa-wand-sparkles,
+.btn.btn-outline-primary:focus .fa-wand-sparkles {
     color: inherit !important;
 }
 
@@ -1992,7 +2001,8 @@ a[href$=".mp4"]::after {
     color: #face00 !important;
 }
 
-.fa-bug {
+.fa-bug,
+.fa-code-branch {
     color: #fbbaa7;
 }
 
@@ -2350,7 +2360,8 @@ a .fa-up-right-from-square {
     color: #f3bf90;
 }
 
-.fa-wand-magic-sparkles {
+.fa-wand-magic-sparkles,
+.fa-wand-sparkles {
     color: #ffe396;
 }
 
@@ -2426,6 +2437,7 @@ a .fa-up-right-from-square {
 [data-bs-theme=light] .fa-bell-concierge,
 [data-bs-theme=light] .fa-brain,
 [data-bs-theme=light] .fa-bug,
+[data-bs-theme=light] .fa-code-branch,
 [data-bs-theme=light] .fa-concierge-bell,
 [data-bs-theme=light] .fa-face-frown,
 [data-bs-theme=light] .fa-life-ring,
@@ -2468,7 +2480,8 @@ a .fa-up-right-from-square {
 [data-bs-theme=light] .fa-scroll,
 [data-bs-theme=light] .fa-star,
 [data-bs-theme=light] .fa-stop-circle,
-[data-bs-theme=light] .fa-wand-magic-sparkles {
+[data-bs-theme=light] .fa-wand-magic-sparkles,
+[data-bs-theme=light] .fa-wand-sparkles {
     /* → #8a6500 = 5.33:1 ✓ */
     color: #8a6500 !important;
 }
@@ -2502,6 +2515,15 @@ a .fa-up-right-from-square {
 
 [data-bs-theme=light] .btn.btn-outline-primary:hover .fa-sitemap,
 [data-bs-theme=light] .btn.btn-outline-primary:focus .fa-sitemap {
+    color: inherit !important;
+}
+
+[data-bs-theme=light] .btn.btn-outline-primary .fa-wand-sparkles {
+    color: #8a6500 !important;
+}
+
+[data-bs-theme=light] .btn.btn-outline-primary:hover .fa-wand-sparkles,
+[data-bs-theme=light] .btn.btn-outline-primary:focus .fa-wand-sparkles {
     color: inherit !important;
 }
 
@@ -3131,12 +3153,4 @@ dialog::backdrop { }
 
 @keyframes slide-in-up {
     0% { transform: translateY(100%); }
-}
-
-/* Dark mode — indigo-slate theme */
-[data-bs-theme=dark] {
-    --bs-body-bg: #1a1b2e;
-    --bs-body-bg-rgb: 26, 27, 46;
-    --bs-body-secondary-bg: #13141f;
-    --bs-border-color: rgba(255, 255, 255, 0.07);
 }

--- a/scripts/bundle.css
+++ b/scripts/bundle.css
@@ -20039,9 +20039,9 @@ readers do not read off random characters that represent icons */
     --bs-primary-text: #13171f;
     --bs-body-color: #fff;
     --bs-body-color-rgb: 255, 255, 255;
-    --bs-body-bg: #13171f;
-    --bs-body-bg-rgb: 19, 23, 31;
-    --bs-body-secondary-bg: #0f1218;
+    --bs-body-bg: #1a1b2e;
+    --bs-body-bg-rgb: 26, 27, 46;
+    --bs-body-secondary-bg: #13141f;
     --bs-link-color: #4FB8F0;
     --bs-link-color-rgb: 79, 184, 240;
     --bs-link-hover-color: var(--bs-link-color);
@@ -20067,7 +20067,7 @@ readers do not read off random characters that represent icons */
     --bs-btn-hover-color: var(--bs-primary-text);
     --bs-nav-link-color: var(--bs-body-color);
     --bs-nav-link-hover-color: var(--bs-link-color);
-    --bs-border-color: #252f3e;
+    --bs-border-color: rgba(255, 255, 255, 0.07);
     --bs-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
     --bs-card-shadow: var(--bs-shadow);
     --bs-box-shadow: var(--bs-shadow);
@@ -20667,6 +20667,15 @@ button.btn-primary-outline:focus {
 
 .btn.btn-outline-primary:hover .fa-sitemap,
 .btn.btn-outline-primary:focus .fa-sitemap {
+    color: inherit !important;
+}
+
+.btn.btn-outline-primary .fa-wand-sparkles {
+    color: #ffe396 !important;
+}
+
+.btn.btn-outline-primary:hover .fa-wand-sparkles,
+.btn.btn-outline-primary:focus .fa-wand-sparkles {
     color: inherit !important;
 }
 
@@ -21972,7 +21981,8 @@ a[href$=".mp4"]::after {
     color: #face00 !important;
 }
 
-.fa-bug {
+.fa-bug,
+.fa-code-branch {
     color: #fbbaa7;
 }
 
@@ -22330,7 +22340,8 @@ a .fa-up-right-from-square {
     color: #f3bf90;
 }
 
-.fa-wand-magic-sparkles {
+.fa-wand-magic-sparkles,
+.fa-wand-sparkles {
     color: #ffe396;
 }
 
@@ -22406,6 +22417,7 @@ a .fa-up-right-from-square {
 [data-bs-theme=light] .fa-bell-concierge,
 [data-bs-theme=light] .fa-brain,
 [data-bs-theme=light] .fa-bug,
+[data-bs-theme=light] .fa-code-branch,
 [data-bs-theme=light] .fa-concierge-bell,
 [data-bs-theme=light] .fa-face-frown,
 [data-bs-theme=light] .fa-life-ring,
@@ -22448,7 +22460,8 @@ a .fa-up-right-from-square {
 [data-bs-theme=light] .fa-scroll,
 [data-bs-theme=light] .fa-star,
 [data-bs-theme=light] .fa-stop-circle,
-[data-bs-theme=light] .fa-wand-magic-sparkles {
+[data-bs-theme=light] .fa-wand-magic-sparkles,
+[data-bs-theme=light] .fa-wand-sparkles {
     /* → #8a6500 = 5.33:1 ✓ */
     color: #8a6500 !important;
 }
@@ -22482,6 +22495,15 @@ a .fa-up-right-from-square {
 
 [data-bs-theme=light] .btn.btn-outline-primary:hover .fa-sitemap,
 [data-bs-theme=light] .btn.btn-outline-primary:focus .fa-sitemap {
+    color: inherit !important;
+}
+
+[data-bs-theme=light] .btn.btn-outline-primary .fa-wand-sparkles {
+    color: #8a6500 !important;
+}
+
+[data-bs-theme=light] .btn.btn-outline-primary:hover .fa-wand-sparkles,
+[data-bs-theme=light] .btn.btn-outline-primary:focus .fa-wand-sparkles {
     color: inherit !important;
 }
 
@@ -23111,12 +23133,4 @@ dialog::backdrop { }
 
 @keyframes slide-in-up {
     0% { transform: translateY(100%); }
-}
-
-/* Dark mode — indigo-slate theme */
-[data-bs-theme=dark] {
-    --bs-body-bg: #1a1b2e;
-    --bs-body-bg-rgb: 26, 27, 46;
-    --bs-body-secondary-bg: #13141f;
-    --bs-border-color: rgba(255, 255, 255, 0.07);
 }


### PR DESCRIPTION
…cards

Adds Single sign-on and URL management feature cards, plus small item additions to Sites dashboard and Scorecards. Adds an optional workExample link (shown as a button) on feature pages that have a public demo, wired up for Scorecards. Fixes /now-scanning/ card inconsistency by removing dead template branches and swapping the icon to fa-bars-progress.