### PR TITLE
Sync shared includes and fix status color CSS variables

### DIFF
--- a/_includes/actions.html
+++ b/_includes/actions.html
@@ -28,7 +28,7 @@
      actionsSocialSites/actionsEmailSites or add a new conditional block
      here - the change propagates everywhere this file is synced.
 #}
-{% set actionsSocialSites = ["https://scangov.com", "https://docs.scangov.org", "https://standards.scangov.org", "https://data.scangov.org"] %}
+{% set actionsSocialSites = ["https://scangov.com", "https://scangov.org", "https://docs.scangov.org", "https://standards.scangov.org", "https://data.scangov.org"] %}
 {% set actionsEmailSites = ["https://scangov.com", "https://scangov.org", "https://standards.scangov.org", "https://docs.scangov.org", "https://data.scangov.org"] %}
 <ul class="actions list-group list-group-horizontal-sm gap-2 mt-3 mb-3 pb-3 border-bottom">
     <li id="rescan-action" class="list-group-item d-none">

--- a/_includes/details.html
+++ b/_includes/details.html
@@ -41,7 +41,7 @@
 </ul>
 {% endif %}
 {% if profile %}
-<ul class="small list-unstyled text-body-secondary font-monospace pb-3 mb-3 border-bottom">
+<ul class="small list-unstyled text-body-secondary font-monospace">
     {% if not mapPage and not orgPage %}
     {% if site.url == 'https://scangov.org' and domain.name %}
     <li>
@@ -65,6 +65,7 @@
     <li>
         Last scan:
         <span id="updated">{{ updates }}</span>
+        &middot; <a href="https://docs.scangov.org/scans/">About scans</a>
     </li>
     {% elif site.url == 'https://my.scangov.com' %}
     <li>

--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -15,9 +15,8 @@
   function updateButton() {
     const scrolled = document.documentElement.scrollTop > window.innerHeight * 0.3;
     const footerVisible = footer && footer.getBoundingClientRect().top < window.innerHeight;
-    const noticeVisible = !!document.getElementById('scan-notice');
     const ctaVisible = ctaSection && ctaSection.getBoundingClientRect().top < window.innerHeight;
-    const visible = scrolled && !footerVisible && !noticeVisible && !ctaVisible;
+    const visible = scrolled && !footerVisible && !ctaVisible;
     feedbackButton.classList.toggle('is-visible', visible);
     feedbackButton.setAttribute('aria-hidden', visible ? 'false' : 'true');
     feedbackButton.setAttribute('tabindex', visible ? '0' : '-1');

--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -122,15 +122,18 @@
     --bs-card-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
     /* Status colors */
     --bs-success: #70e17b;
+    --bs-success-rgb: 112, 225, 123;
     --bs-bg-success: #70e17b;
     --bs-bg-success-rgb: 112, 225, 123;
     --bs-border-success: #70e17b;
     --bs-warning: #face00;
+    --bs-warning-rgb: 250, 206, 0;
     --bs-text-warning: #000000;
     --bs-bg-warning: #face00;
     --bs-bg-warning-rgb: 250, 206, 0;
     --bs-border-warning: #face00;
     --bs-danger: #e41d3d;
+    --bs-danger-rgb: 228, 29, 61;
     --bs-text-danger: #ffffff;
     --bs-bg-danger: #e41d3d;
     --bs-bg-danger-rgb: 228, 29, 61;
@@ -2883,34 +2886,6 @@ th a:focus i, th a:focus svg {
 
 .js-sidenav a:hover {
     color: var(--bs-link-color) !important;
-}
-
-.scan-notice {
-    position: fixed;
-    bottom: 1rem;
-    left: 1rem;
-    right: 1rem;
-    z-index: 1050;
-    margin: 0;
-    padding-top: 0.75rem;
-    padding-bottom: 0.75rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.scan-notice .btn-close {
-    flex-shrink: 0;
-    margin-left: auto;
-}
-
-@media (min-width: 768px) {
-    .scan-notice {
-        width: 75%;
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-    }
 }
 
 /* Actions list: separate boxes — restore left border + full radius on every item */


### PR DESCRIPTION
- actions.html: add scangov.org to actionsSocialSites so scangov's share dropdown gets LinkedIn/Bluesky/Mastodon/X like every other site
- details.html: remove the divider border-bottom/padding under the profile details list, add an "About scans" link next to Last scan
- feedback.html: remove the dead scan-notice presence check that was silently keeping the "Get ScanGov" CTA permanently hidden on scangov
- scangov.css: add missing --bs-success/warning/danger-rgb variables so text-success/warning/danger utilities use the brand palette instead of falling back to stock Bootstrap colors, and remove the now-unused .scan-notice rules