### PR TITLE
Sync scangov.css from components, gitignore local Claude content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ _site
 **/.DS_Store
 node_modules/
 content/news/drafts/
+
+docs/plans/
+.claude

--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -1424,11 +1424,6 @@ a.card {
 
 /* Forms */
 
-form button[type="submit"],
-form input[type="submit"] {
-    margin-bottom: 2rem;
-}
-
 td form button[type="submit"],
 td form input[type="submit"] {
     margin-bottom: 0;
@@ -1478,6 +1473,25 @@ input[type="submit"] {
 
 .progress {
     height: 6px;
+}
+
+.border-list-item {
+    border: 1px solid var(--bs-border-color);
+    padding: 0.5rem;
+}
+
+.border-list-item:first-child {
+    border-top-left-radius: var(--bs-border-radius);
+    border-top-right-radius: var(--bs-border-radius);
+}
+
+.border-list-item:last-child {
+    border-bottom-left-radius: var(--bs-border-radius);
+    border-bottom-right-radius: var(--bs-border-radius);
+}
+
+.border-list-item:hover {
+    background-color: rgba(var(--bs-emphasis-color-rgb), 0.075);
 }
 
 /* SVG */
@@ -2067,6 +2081,16 @@ td a:hover .fa-circle-info {
     color: var(--bs-body-color) !important;
 }
 
+.js-sidenav a .fa-circle-question,
+.js-sidenav a:hover .fa-circle-question {
+    color: #97d4ea !important;
+}
+
+.js-sidenav a .fa-circle-info,
+.js-sidenav a:hover .fa-circle-info {
+    color: #b8d293 !important;
+}
+
 .fa-triangle-exclamation {
     color: #f4a0a0;
 }
@@ -2599,6 +2623,16 @@ a .fa-up-right-from-square {
 [data-bs-theme=light] a .fa-circle-info,
 [data-bs-theme=light] a:hover .fa-circle-info {
     color: inherit !important;
+}
+
+[data-bs-theme=light] .js-sidenav a .fa-circle-question,
+[data-bs-theme=light] .js-sidenav a:hover .fa-circle-question {
+    color: #1a6fa0 !important;
+}
+
+[data-bs-theme=light] .js-sidenav a .fa-circle-info,
+[data-bs-theme=light] .js-sidenav a:hover .fa-circle-info {
+    color: #2d7a3a !important;
 }
 
 [data-bs-theme=light] .fa-triangle-exclamation {


### PR DESCRIPTION
Picks up sidebar icon-color fixes and sticky-footer layout from components' canonical scangov.css.