### PR TITLE
Fix link text and INP issues found by ScanGov scan

### DIFF
--- a/_includes/feedback.html
+++ b/_includes/feedback.html
@@ -24,7 +24,15 @@
 
   const hiddenPaths = ['/plans/', '/demo/', '/demo-confirm/', '/contact/'];
   if (window.location.hostname !== 'my.scangov.com' && !hiddenPaths.includes(window.location.pathname)) {
-    window.addEventListener('scroll', updateButton);
+    let ticking = false;
+    window.addEventListener('scroll', function() {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(function() {
+        updateButton();
+        ticking = false;
+      });
+    }, { passive: true });
     updateButton();
   }
 </script>

--- a/_includes/plans.html
+++ b/_includes/plans.html
@@ -16,7 +16,7 @@
           </ul>
         </div>
         <div class="card-footer">
-          <a href="{{ item.ctaUrl }}" class="w-100 btn btn-lg btn-primary" aria-label="{{ item.ctaText }} {{ item.title }} plan" title="{{ item.ctaText }} {{ item.title }} plan">{{ item.ctaText }}</a>
+          <a href="{{ item.ctaUrl }}" class="w-100 btn btn-lg btn-primary">{{ item.ctaText }}<span class="visually-hidden"> {{ item.title }} plan</span></a>
         </div>
       </div>
     </div>

--- a/content/feature.html
+++ b/content/feature.html
@@ -46,6 +46,7 @@ eleventyComputed:
         <iframe
           src="https://www.youtube.com/embed/{{ feature.video }}?modestbranding=1&rel=0"
           title="{{ feature.title }}"
+          loading="lazy"
           allowfullscreen></iframe>
       </div>
     </div>

--- a/content/index.html
+++ b/content/index.html
@@ -148,21 +148,23 @@ home: true
   </div>
   <div class="row align-items-start">
     <div class="col-12 col-md-4 d-none d-md-block">
-      <a href="{{ site.baseurl }}government-experience-awards" aria-label="Government Experience Awards">
+      <a href="{{ site.baseurl }}government-experience-awards">
         <img
           src="/../public/assets/img/govx-og.png"
           class="mb-4 img-fluid border rounded shadow"
           loading="lazy"
           alt="">
+        <span class="visually-hidden">Government Experience Awards</span>
       </a>
     </div>
     <div class="col-12 col-md-8">
-      <a href="{{ site.baseurl }}government-experience-awards" aria-label="Government Experience Awards">
+      <a href="{{ site.baseurl }}government-experience-awards">
         <img
           src="/../public/assets/img/govx-og.png"
           class="my-4 img-fluid border rounded shadow d-block d-md-none"
           loading="lazy"
           alt="">
+        <span class="visually-hidden">Government Experience Awards</span>
       </a>
       <blockquote class="mb-3">
         <p class="fs-5">


### PR DESCRIPTION
- Add visually-hidden text to GovX Awards image links and plans CTA buttons so link purpose isn't conveyed by aria-label/title alone
- Lazy-load the feature-page YouTube iframe embed
- Throttle the sitewide feedback-button scroll listener with requestAnimationFrame and mark it passive, removing an unthrottled forced-reflow handler that was hurting INP on every page