### PR TITLE
Sync scangov.css with components

### DIFF
--- a/public/css/scangov.css
+++ b/public/css/scangov.css
@@ -652,16 +652,6 @@ button.btn-primary-outline {
     transition: filter 0.25s ease, box-shadow 0.25s ease;
 }
 
-button.btn-primary-outline:hover,
-button.btn-primary-outline:focus {
-    color: var(--bs-body-bg) !important;
-}
-
-.btn-primary-outline:hover i,
-.btn-primary-outline:hover svg {
-    color: inherit !important;
-}
-
 .btn.btn-outline-primary {
     --bs-btn-color: var(--bs-body-color);
     --bs-btn-border-color: var(--bs-border-color);
@@ -746,8 +736,8 @@ button.btn-primary-outline:focus {
     transition: filter 0.25s ease;
 }
 
-.btn-primary:hover, .btn-primary:focus,
-.feedback:hover, .feedback:focus {
+.btn-primary:hover, .btn-primary:focus, .btn-primary:active,
+.feedback:hover, .feedback:focus, .feedback:active {
     filter: brightness(1.3);
     box-shadow: var(--bs-box-shadow-md);
     background-color: var(--bs-primary) !important;
@@ -755,14 +745,15 @@ button.btn-primary-outline:focus {
     border-color: var(--bs-primary) !important;
 }
 
-a.btn-primary-outline:not(.active):hover,
 .btn-primary-outline:not(.active):hover,
-a.btn-primary-outline:not(.active):focus,
-a.btn-primary-outline.active,
+.btn-primary-outline:not(.active):focus,
+.btn-primary-outline:not(.active):active,
 .btn-primary-outline.active {
     filter: brightness(1.3);
     box-shadow: var(--bs-box-shadow-md);
     border: 1px solid var(--bs-border-color);
+    background-color: var(--bs-body-bg) !important;
+    color: var(--bs-body-color) !important;
 }
 
 @media (max-width: 767.98px) {
@@ -2160,6 +2151,22 @@ td a:hover .fa-circle-info {
     color: #a8f2ff;
 }
 
+.fa-file-arrow-down {
+    color: #a8f2ff;
+}
+
+.fa-file-csv {
+    color: #a8f2ff;
+}
+
+.fa-file-code {
+    color: #a8f2ff;
+}
+
+.fa-markdown {
+    color: #a8f2ff;
+}
+
 .fa-filter {
     color: #cbc4f2;
 }
@@ -2576,6 +2583,10 @@ a .fa-up-right-from-square {
 [data-bs-theme=light] .fa-envelope,
 [data-bs-theme=light] .fa-file,
 [data-bs-theme=light] .fa-file-lines,
+[data-bs-theme=light] .fa-file-arrow-down,
+[data-bs-theme=light] .fa-file-csv,
+[data-bs-theme=light] .fa-file-code,
+[data-bs-theme=light] .fa-markdown,
 [data-bs-theme=light] .fa-linkedin,
 [data-bs-theme=light] .fa-linkedin-in,
 [data-bs-theme=light] .fa-x-twitter,
@@ -2616,7 +2627,8 @@ a .fa-up-right-from-square {
     color: #5b4ea0 !important;
 }
 
-[data-bs-theme=light] .feedback .fa-rocket {
+[data-bs-theme=light] .feedback .fa-rocket,
+[data-bs-theme=light] .feedback .fa-message {
     color: inherit !important;
 }
 
@@ -3207,4 +3219,113 @@ dialog::backdrop { }
 
 .card-body.stretched-link:hover {
     color: inherit !important;
+}
+
+/* -----------------------------------------------------------------------
+   Migrated from my.scangov.com/public/css/style.css (style.css retired).
+   ----------------------------------------------------------------------- */
+
+[data-bs-theme=dark] .text-bg-info {
+  color: #fff !important;
+  background-color: #2672de !important;
+}
+
+[data-bs-theme=dark] button[type="submit"] {
+  min-width: 80px;
+}
+
+input[type="radio"],
+.form-check-input {
+  border-color: #9ca3ab;
+  border-width: 2px;
+}
+
+body[data-bs-theme='dark'] footer img,
+body[data-bs-theme='dark'] ul.navbar-nav img {
+  filter: invert(1);
+}
+
+.card-footer {
+  color: inherit !important;
+}
+
+a.cardlink {
+  text-decoration: none;
+  color: #fff;
+}
+
+/* Bootstrap dark mode WCAG compliance override */
+[data-bs-theme='dark'] .text-bg-danger .card {
+  --bs-card-cap-bg: rgba(var(--bs-body-color-rgb), 0);
+}
+
+.list-group-item.list-group-item-action {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+
+.constrained-sm {
+  margin: 1rem 0;
+  max-width: 600px;
+}
+
+button.btn.btn-primary[disabled] {
+  background: none;
+}
+
+.nav-pills .nav-item a.btn-primary-outline:focus-visible {
+  color: var(--bs-btn-hover-color) !important;
+  background-color: var(--bs-nav-pills-link-active-bg);
+}
+
+.nav-pills .nav-item a.btn-primary-outline.active:focus-visible {
+  border-color: white;
+}
+
+.btn {
+  text-wrap: nowrap;
+}
+
+td.padded-cell {
+  padding: 1rem;
+}
+
+.d-backlog .icon-open, .d-doing .icon-open {
+  display: inline;
+}
+
+.d-done .icon-open, .d-backlog .icon-open {
+  display: none;
+}
+
+.d-backlog .icon-closed, .d-doing .icon-closed {
+  display: none;
+}
+
+.d-done .icon-closed {
+  display: inline;
+}
+
+.js-subfilters {
+  background-color: var(--bs-badge-bg);
+  color: var(--bs-body-bg);
+}
+
+.js-top-badge {
+  position: absolute;
+  top: 0;
+  right: -1rem;
+}
+
+[data-bs-theme=dark] .form-select.js-subfilters {
+  --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e")
+}
+
+blockquote .lead {
+  margin: 2rem 0;
+}
+
+#pageInfo th {
+  min-width: 80px;
 }


### PR DESCRIPTION
Picks up my.scangov.com's style.css migration plus icon-color rules this repo's copy had fallen behind on.