### PR TITLE
Upgrade sharp, js-yaml, linkify-it to fix Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -303,9 +303,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
-			"integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+			"version": "1.11.3",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -369,10 +369,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/@img/colour": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+			"integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@img/sharp-darwin-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-			"integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+			"integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
 			"cpu": [
 				"arm64"
 			],
@@ -382,19 +391,19 @@
 				"darwin"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-arm64": "1.0.4"
+				"@img/sharp-libvips-darwin-arm64": "1.3.2"
 			}
 		},
 		"node_modules/@img/sharp-darwin-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-			"integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+			"integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
 			"cpu": [
 				"x64"
 			],
@@ -404,19 +413,38 @@
 				"darwin"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-x64": "1.0.4"
+				"@img/sharp-libvips-darwin-x64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-freebsd-wasm32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+			"integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.3"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/@img/sharp-libvips-darwin-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-			"integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+			"integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
 			"cpu": [
 				"arm64"
 			],
@@ -430,9 +458,9 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-darwin-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-			"integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+			"integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
 			"cpu": [
 				"x64"
 			],
@@ -446,11 +474,14 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-arm": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-			"integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+			"integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
 			"cpu": [
 				"arm"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -462,11 +493,52 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-			"integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+			"integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+			"integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+			"cpu": [
+				"ppc64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-riscv64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+			"integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -478,11 +550,14 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-s390x": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-			"integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+			"integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
 			"cpu": [
 				"s390x"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -494,11 +569,14 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linux-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-			"integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+			"integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -510,11 +588,14 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-			"integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+			"integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -526,11 +607,14 @@
 			}
 		},
 		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-			"integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+			"integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -542,33 +626,39 @@
 			}
 		},
 		"node_modules/@img/sharp-linux-arm": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-			"integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+			"integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
 			"cpu": [
 				"arm"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm": "1.0.5"
+				"@img/sharp-libvips-linux-arm": "1.3.2"
 			}
 		},
 		"node_modules/@img/sharp-linux-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-			"integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+			"integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -576,43 +666,99 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm64": "1.0.4"
+				"@img/sharp-libvips-linux-arm64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-ppc64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+			"integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+			"cpu": [
+				"ppc64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-ppc64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-riscv64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+			"integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"libc": [
+				"glibc"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-riscv64": "1.3.2"
 			}
 		},
 		"node_modules/@img/sharp-linux-s390x": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-			"integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+			"integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
 			"cpu": [
 				"s390x"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-s390x": "1.0.4"
+				"@img/sharp-libvips-linux-s390x": "1.3.2"
 			}
 		},
 		"node_modules/@img/sharp-linux-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-			"integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+			"integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -620,43 +766,49 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linux-x64": "1.0.4"
+				"@img/sharp-libvips-linux-x64": "1.3.2"
 			}
 		},
 		"node_modules/@img/sharp-linuxmusl-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-			"integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+			"integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
 			}
 		},
 		"node_modules/@img/sharp-linuxmusl-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-			"integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+			"integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -664,38 +816,73 @@
 				"linux"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.2"
 			}
 		},
 		"node_modules/@img/sharp-wasm32": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-			"integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
-			"cpu": [
-				"wasm32"
-			],
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+			"integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
 			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/runtime": "^1.2.0"
+				"@emnapi/runtime": "^1.11.1"
 			},
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-webcontainers-wasm32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+			"integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.3"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-arm64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+			"integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/@img/sharp-win32-ia32": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-			"integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+			"integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
 			"cpu": [
 				"ia32"
 			],
@@ -705,16 +892,16 @@
 				"win32"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": "^20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
 		},
 		"node_modules/@img/sharp-win32-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-			"integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+			"integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
 			"cpu": [
 				"x64"
 			],
@@ -724,7 +911,7 @@
 				"win32"
 			],
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
@@ -1126,19 +1313,6 @@
 				"node": ">= 10.0"
 			}
 		},
-		"node_modules/color": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-			"integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1",
-				"color-string": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=12.5.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1156,16 +1330,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
-		},
-		"node_modules/color-string": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
-			}
 		},
 		"node_modules/commander": {
 			"version": "10.0.1",
@@ -1244,9 +1408,9 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-			"integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
@@ -1646,9 +1810,9 @@
 			}
 		},
 		"node_modules/gray-matter/node_modules/js-yaml": {
-			"version": "3.14.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
@@ -1792,12 +1956,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"license": "MIT"
-		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1905,9 +2063,19 @@
 			}
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -1944,9 +2112,19 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"uc.micro": "^2.0.0"
@@ -2581,9 +2759,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -2627,42 +2805,52 @@
 			"license": "ISC"
 		},
 		"node_modules/sharp": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-			"integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
-			"hasInstallScript": true,
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+			"integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"color": "^4.2.3",
-				"detect-libc": "^2.0.3",
-				"semver": "^7.6.3"
+				"@img/colour": "^1.1.0",
+				"detect-libc": "^2.1.2",
+				"semver": "^7.8.5"
 			},
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-darwin-arm64": "0.33.5",
-				"@img/sharp-darwin-x64": "0.33.5",
-				"@img/sharp-libvips-darwin-arm64": "1.0.4",
-				"@img/sharp-libvips-darwin-x64": "1.0.4",
-				"@img/sharp-libvips-linux-arm": "1.0.5",
-				"@img/sharp-libvips-linux-arm64": "1.0.4",
-				"@img/sharp-libvips-linux-s390x": "1.0.4",
-				"@img/sharp-libvips-linux-x64": "1.0.4",
-				"@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-				"@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-				"@img/sharp-linux-arm": "0.33.5",
-				"@img/sharp-linux-arm64": "0.33.5",
-				"@img/sharp-linux-s390x": "0.33.5",
-				"@img/sharp-linux-x64": "0.33.5",
-				"@img/sharp-linuxmusl-arm64": "0.33.5",
-				"@img/sharp-linuxmusl-x64": "0.33.5",
-				"@img/sharp-wasm32": "0.33.5",
-				"@img/sharp-win32-ia32": "0.33.5",
-				"@img/sharp-win32-x64": "0.33.5"
+				"@img/sharp-darwin-arm64": "0.35.3",
+				"@img/sharp-darwin-x64": "0.35.3",
+				"@img/sharp-freebsd-wasm32": "0.35.3",
+				"@img/sharp-libvips-darwin-arm64": "1.3.2",
+				"@img/sharp-libvips-darwin-x64": "1.3.2",
+				"@img/sharp-libvips-linux-arm": "1.3.2",
+				"@img/sharp-libvips-linux-arm64": "1.3.2",
+				"@img/sharp-libvips-linux-ppc64": "1.3.2",
+				"@img/sharp-libvips-linux-riscv64": "1.3.2",
+				"@img/sharp-libvips-linux-s390x": "1.3.2",
+				"@img/sharp-libvips-linux-x64": "1.3.2",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+				"@img/sharp-linux-arm": "0.35.3",
+				"@img/sharp-linux-arm64": "0.35.3",
+				"@img/sharp-linux-ppc64": "0.35.3",
+				"@img/sharp-linux-riscv64": "0.35.3",
+				"@img/sharp-linux-s390x": "0.35.3",
+				"@img/sharp-linux-x64": "0.35.3",
+				"@img/sharp-linuxmusl-arm64": "0.35.3",
+				"@img/sharp-linuxmusl-x64": "0.35.3",
+				"@img/sharp-webcontainers-wasm32": "0.35.3",
+				"@img/sharp-win32-arm64": "0.35.3",
+				"@img/sharp-win32-ia32": "0.35.3",
+				"@img/sharp-win32-x64": "0.35.3"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/shebang-command": {
@@ -2696,15 +2884,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/simple-swizzle": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-arrayish": "^0.3.1"
 			}
 		},
 		"node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,13 @@
 		"clean-css": "^5.3.3",
 		"html-minifier-terser": "^7.2.0",
 		"purgecss": "^7.0.2"
+	},
+	"overrides": {
+		"sharp": "^0.35.3",
+		"js-yaml": "^4.3.0",
+		"gray-matter": {
+			"js-yaml": "^3.15.0"
+		},
+		"linkify-it": "^5.0.2"
 	}
 }


### PR DESCRIPTION
Add npm overrides for sharp (^0.35.3), js-yaml (^4.3.0 direct / ^3.15.0 under gray-matter to preserve its safeLoad/safeDump API), and linkify-it (^5.0.2).