### PR TITLE
Add scan check tool and tools index page

### DIFF
--- a/_data/footer.json
+++ b/_data/footer.json
@@ -57,6 +57,10 @@
     {
       "title": "Now scanning ...",
       "url": "/now-scanning"
+    },
+    {
+      "title": "Tools",
+      "url": "/tools/"
     }
   ],
   [

--- a/content/indicator.html
+++ b/content/indicator.html
@@ -74,7 +74,7 @@ eleventyComputed:
     <div class="col-12 col-md-4 d-flex align-items-stretch">
       <div class="card">
         <div class="card-body">
-          <i class="fa-solid fa-triangle-exclamation fa-lg d-block mb-2"></i>
+          <i class="fa-solid fa-triangle-exclamation text-neutral-icon fa-lg d-block mb-2"></i>
           <h2>Risks</h2>
           <p>{{ indicator.risk }}</p>
         </div>

--- a/content/tools/index.html
+++ b/content/tools/index.html
@@ -1,0 +1,22 @@
+---
+layout: layouts/default
+date: 2026-08-01
+author: ScanGov
+title: "Tools"
+description: "Free tools from ScanGov."
+permalink: /tools/
+---
+
+<div class="container">
+  <div class="row g-3">
+    <div class="col-12 col-sm-12 col-md-4 col-lg-4 col-xl-4 d-flex align-items-stretch">
+      <div class="card">
+        <div class="card-body">
+          <i class="fa-solid fa-check fa-lg d-block mb-2" aria-hidden="true"></i>
+          <h2 class="h4 mb-2 mt-3"><a href="/tools/scan-check/" class="stretched-link">Scan check</a></h2>
+          <p class="card-text small">Check if ScanGov can scan your website.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/content/tools/scan-check.html
+++ b/content/tools/scan-check.html
@@ -9,31 +9,46 @@ permalink: /tools/scan-check/
 
 <div class="container">
   <div class="row">
-    <div class="col-12 col-sm-12 col-md-1 col-lg-1 col-xl-1"></div>
-    <div class="col-12 col-sm-12 col-md-10 col-lg-10 col-xl-10">
+    <div class="col-12 col-sm-12 col-md-2 col-lg-2 col-xl-2"></div>
+    <div class="col-12 col-sm-12 col-md-8 col-lg-8 col-xl-8">
 
       <div id="scan-form">
-        <form class="centered-sm" id="scan-check-form">
+        <form id="scan-check-form">
           <div class="mb-3">
-            <label for="site" class="form-label">Domain or URL</label>
-            <input type="text" class="form-control" name="site" id="site" placeholder="example.gov" required>
+            <label for="site" class="form-label">Domain <i class="fa-solid fa-asterisk" aria-hidden="true"></i></label>
+            <input
+              type="text"
+              class="form-control form-control-lg"
+              name="site"
+              id="site"
+              placeholder="example.gov"
+              required>
           </div>
-          <button type="submit" class="btn btn-primary" id="submitbutton">Check</button>
+          <button
+            type="submit"
+            class="btn btn-primary btn-lg"
+            id="submitbutton">Check</button>
         </form>
       </div>
 
       <div id="scan-loading" class="d-none text-center py-5">
         <div class="spinner-border" role="status">
-          <span class="visually-hidden">Checking...</span>
+          <span class="visually-hidden">Checking ...</span>
         </div>
-        <p class="mt-3">Checking site accessibility...</p>
+        <p class="mt-3">Checking if we can reach <span id="loading-domain" class="font-monospace"></span> ...</p>
       </div>
 
       <div id="scan-results" class="d-none"></div>
 
-      <div class="alert alert-secondary mt-4">
+      <div class="alert alert-info mt-4">
         <h2>About</h2>
-        <p>This tool checks whether ScanGov can reach your website using two methods: a standard HTTP fetch and a Playwright browser fallback. If both methods fail, ScanGov may not be able to audit your site.</p>
+        <p>This tool checks whether ScanGov can reach your website using two methods:</p>
+
+        <ul>
+          <li>Standard HTTP fetch</li>
+          <li>Playwright browser fallback</li>
+        </ul>
+        <p>If both methods fail, ScanGov may not be able to audit your site.</p>
         <h2>Common issues</h2>
         <ul>
           <li>Web application firewalls (WAFs) blocking automated requests</li>
@@ -44,7 +59,7 @@ permalink: /tools/scan-check/
       </div>
 
     </div>
-    <div class="col-12 col-sm-12 col-md-1 col-lg-1 col-xl-1"></div>
+    <div class="col-12 col-sm-12 col-md-2 col-lg-2 col-xl-2"></div>
   </div>
 </div>
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -148,12 +148,36 @@ export default async function (eleventyConfig) {
                     {
                         raw: content,
                         extension: 'html' // Indicate the content type
-                    }
+                    },
+                    // Markup built entirely in JS via innerHTML (e.g. public/js/scan-check.js's
+                    // results markup - alerts, tables, buttons) never appears in a page's static
+                    // HTML, so PurgeCSS strips its CSS as "unused" even though JS injects it at
+                    // runtime. Scanning the JS source directly catches literal classes/tags
+                    // (table, th, caption, etc.) without hand-listing every one.
+                    'public/js/*.js',
                 ],
                 css: ['scripts/bundle.css'],
+                // Classes built via template-literal interpolation (e.g. `alert-${verdictClass}`)
+                // aren't literal text PurgeCSS can find even in the JS source above, since the
+                // real class name only exists at runtime. Safelist those patterns explicitly.
+                safelist: [/^alert-/, /^text-bg-/, /^fa-/, /^btn-/, 'font-monospace', 'alert-heading', 'border'],
             })
 
-            let minifiedCSS = new CleanCSS({}).minify(purgeCSSResults[0].css).styles;
+            // bundle.css's Font Awesome @font-face rules use paths relative to its
+            // original location (public/assets/font-awesome/css/all.css), e.g.
+            // url(../webfonts/fa-solid-900.woff2). Once inlined into a page's <style>
+            // tag, relative url()s resolve against the page's own URL instead, which
+            // 404s on every page except one at exactly the right nesting depth. Icons
+            // present in the static HTML get pre-rendered to <svg> at build time (via
+            // the font-awesome eleventy plugin) so they never hit this, but any icon
+            // added client-side via JS (e.g. public/js/scan-check.js) stays a plain
+            // <i> tag relying on the actual webfont file, so the path must be absolute.
+            let purgedCSS = purgeCSSResults[0].css.replaceAll(
+                '../webfonts/',
+                '/assets/font-awesome/webfonts/'
+            );
+
+            let minifiedCSS = new CleanCSS({}).minify(purgedCSS).styles;
 			return content.replace('<!--put inlined css here-->',`<style>${minifiedCSS}</style>`);
 		}
 

--- a/public/js/scan-check.js
+++ b/public/js/scan-check.js
@@ -1,10 +1,26 @@
 const API_BASE = 'https://audits.my.scangov.com';
+const STATUS_DEFS_URL = 'https://raw.githubusercontent.com/ScanGov/data/refs/heads/main/status.json';
+
+let statusDefsPromise = null;
+function getStatusDefs() {
+  if (!statusDefsPromise) {
+    statusDefsPromise = fetch(STATUS_DEFS_URL).then((r) => r.json()).catch(() => []);
+  }
+  return statusDefsPromise;
+}
+
+function resolveStatusCode(data) {
+  if (data.fetch && data.fetch.statusCode) return data.fetch.statusCode;
+  if (data.playwright && data.playwright.statusCode) return data.playwright.statusCode;
+  return null;
+}
 
 const form = document.getElementById('scan-check-form');
 const formSection = document.getElementById('scan-form');
 const loadingSection = document.getElementById('scan-loading');
 const resultsSection = document.getElementById('scan-results');
 const siteInput = document.getElementById('site');
+const loadingDomain = document.getElementById('loading-domain');
 
 function showForm() {
   formSection.classList.remove('d-none');
@@ -15,10 +31,11 @@ function showForm() {
   location.hash = '';
 }
 
-function showLoading() {
+function showLoading(domain) {
   formSection.classList.add('d-none');
   loadingSection.classList.remove('d-none');
   resultsSection.classList.add('d-none');
+  loadingDomain.textContent = domain;
 }
 
 function showResults(html) {
@@ -28,30 +45,44 @@ function showResults(html) {
   resultsSection.classList.remove('d-none');
 }
 
-function statusBadge(success) {
-  if (success) {
-    return '<span class="badge text-bg-success">Success</span>';
-  }
-  return '<span class="badge text-bg-danger">Failed</span>';
+function statusText(success) {
+  return success ? 'Success' : 'Failed';
 }
 
-function renderResults(data) {
+function toAbsoluteUrl(domain) {
+  return /^https?:\/\//i.test(domain) ? domain : `https://${domain}`;
+}
+
+function checkAnotherSiteButton() {
+  return `
+      <div class="d-flex align-items-center gap-3">
+        <a href="/plans" class="btn btn-primary">
+          <i class="fa-solid fa-rocket me-2" aria-hidden="true"></i>Get started</a>
+        <button class="btn btn-outline-primary border mt-0" id="new-check-btn">
+          <i class="fa-solid fa-check me-2" aria-hidden="true"></i>Check another site</button>
+      </div>
+    `;
+}
+
+function renderResults(data, statusDef) {
   const domain = data.url;
   const canScan = data.canScan;
 
   const verdictClass = canScan ? 'success' : 'danger';
+  const verdictIcon = canScan ? 'fa-circle-check' : 'fa-circle-xmark';
+  const domainLink = `<a href="${toAbsoluteUrl(domain)}" target="_blank" rel="noopener noreferrer" class="font-monospace">${domain}</a>`;
   const verdictText = canScan
-    ? 'Yes, we can scan this site'
-    : 'We cannot scan this site';
+    ? `Yes, we can scan ${domainLink}`
+    : `We cannot scan ${domainLink}`;
 
   let fetchDetail = '';
   if (data.fetch) {
     fetchDetail = `
       <tr>
         <td>HTTP fetch</td>
-        <td>${statusBadge(data.fetch.success)}</td>
-        <td>${data.fetch.statusCode || '--'}</td>
-        <td>${data.fetch.error || '--'}</td>
+        <td>${statusText(data.fetch.success)}</td>
+        <td>${data.fetch.statusCode || '—'}</td>
+        <td>${data.fetch.error || '—'}</td>
       </tr>`;
   }
 
@@ -60,88 +91,98 @@ function renderResults(data) {
     playwrightDetail = `
       <tr>
         <td>Playwright browser</td>
-        <td><span class="badge text-bg-secondary">Not needed</span></td>
-        <td>--</td>
-        <td>--</td>
+        <td>Not needed</td>
+        <td>—</td>
+        <td>—</td>
       </tr>`;
   } else if (data.playwright) {
     playwrightDetail = `
       <tr>
         <td>Playwright browser</td>
-        <td>${statusBadge(data.playwright.success)}</td>
-        <td>${data.playwright.statusCode || '--'}</td>
-        <td>${data.playwright.error || '--'}</td>
+        <td>${statusText(data.playwright.success)}</td>
+        <td>${data.playwright.statusCode || '—'}</td>
+        <td>${data.playwright.error || '—'}</td>
       </tr>`;
   }
 
   return `
-    <div class="card text-bg-${verdictClass} mb-4">
-      <div class="card-body text-center py-4">
-        <h2 class="card-title h4 mb-1">${verdictText}</h2>
-        <p class="card-text mb-0">${domain}</p>
+    <div class="alert alert-${verdictClass} mb-4" role="alert">
+      <h2 class="alert-heading h3">${verdictText} <i class="fa-solid ${verdictIcon}" aria-hidden="true"></i></h2>
+    </div>
+
+    ${!canScan ? `
+    <div class="alert alert-info mb-4" role="alert">
+      <h2 class="h3">Why</h2>
+      ${statusDef ? `
+      <h3 class="h4">Description</h3>
+      <p>${statusDef.description}</p>
+      ${statusDef.problem ? `
+      <h3 class="h4">Problem</h3>
+      <p>${statusDef.problem}</p>
+      ` : ''}
+      ${statusDef.recommendation ? `
+      <h3 class="h4">Recommendation</h3>
+      <p>${statusDef.recommendation}</p>
+      ` : ''}
+      ` : ''}
+
+      <h3 class="h4">Details</h3>
+      <div class="table-responsive">
+        <table class="table">
+          <caption class="visually-hidden">Scan check details for ${domain}</caption>
+          <thead>
+            <tr>
+              <th scope="col">Method</th>
+              <th scope="col">Result</th>
+              <th scope="col">Code</th>
+              <th scope="col">Error</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${fetchDetail}
+            ${playwrightDetail}
+          </tbody>
+        </table>
       </div>
-    </div>
 
-    <h3>Details</h3>
-    <div class="table-responsive">
-      <table class="table">
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>Result</th>
-            <th>Status code</th>
-            <th>Error</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${fetchDetail}
-          ${playwrightDetail}
-        </tbody>
-      </table>
+      <h3 class="h4">ScanGovBot</h3>
+      <p>Learn more: <a href="https://scangov.com/bot" class="font-monospace">https://scangov.com/bot</a></p>
     </div>
+    ` : ''}
 
-    <div class="mt-3">
-      <button class="btn btn-primary me-2" id="retry-btn">Run again</button>
-      <button class="btn btn-outline-secondary" id="new-check-btn">Check another site</button>
-    </div>`;
+    ${checkAnotherSiteButton()}`;
 }
 
 async function runScan(domain) {
-  showLoading();
+  showLoading(domain);
   location.hash = domain;
 
   try {
-    const response = await fetch(`${API_BASE}/scan-check?url=${encodeURIComponent(domain)}`);
+    const [response, statusDefs] = await Promise.all([
+      fetch(`${API_BASE}/scan-check?url=${encodeURIComponent(domain)}`),
+      getStatusDefs(),
+    ]);
 
     if (!response.ok) {
       const err = await response.json().catch(() => ({}));
       showResults(`
-        <div class="alert alert-danger">
+        <div class="alert alert-danger" role="alert">
           Scan check failed: ${err.error || `HTTP ${response.status}`}
         </div>
-        <div class="mt-3">
-          <button class="btn btn-primary me-2" id="retry-btn">Run again</button>
-          <button class="btn btn-outline-secondary" id="new-check-btn">Check another site</button>
-        </div>`);
+        ${checkAnotherSiteButton()}`);
     } else {
       const data = await response.json();
-      showResults(renderResults(data));
+      const statusDef = statusDefs.find((s) => s.code === resolveStatusCode(data));
+      showResults(renderResults(data, statusDef));
     }
   } catch {
     showResults(`
-      <div class="alert alert-danger">
+      <div class="alert alert-danger" role="alert">
         Unable to connect to scan check service. Please try again.
       </div>
-      <div class="mt-3">
-        <button class="btn btn-primary me-2" id="retry-btn">Run again</button>
-        <button class="btn btn-outline-secondary" id="new-check-btn">Check another site</button>
-      </div>`);
+      ${checkAnotherSiteButton()}`);
   }
 
-  const retryBtn = document.getElementById('retry-btn');
-  if (retryBtn) {
-    retryBtn.addEventListener('click', () => runScan(domain));
-  }
   const newCheckBtn = document.getElementById('new-check-btn');
   if (newCheckBtn) {
     newCheckBtn.addEventListener('click', showForm);


### PR DESCRIPTION
New /tools/scan-check/ page lets visitors check whether ScanGov can reach their site, pulling problem/recommendation copy live from data/status.json to explain failures and suggest fixes. Adds a /tools/ index page with a Scan check card, a Tools footer link, and fixes two build-pipeline bugs surfaced along the way:

- PurgeCSS only scans a page's static HTML, so classes and tags that only exist in JS-built markup (alerts, tables, icons) were being stripped as unused. Now also scans public/js/*.js directly, plus a safelist for classes built via template-literal interpolation.
- bundle.css's Font Awesome @font-face rules use paths relative to their original file location, which break once inlined into a page's <style> tag (relative URLs then resolve against the page's own URL instead). Rewritten to absolute paths during inlining.

content/indicator.html references a text-neutral-icon class that depends on a separate, not-yet-merged components repo PR — inert until that lands and this repo re-syncs scangov.css.